### PR TITLE
feat: Cognito Sub取得処理改修の実装

### DIFF
--- a/back/lambda/handler.go
+++ b/back/lambda/handler.go
@@ -1,0 +1,154 @@
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/beego/beego/v2/server/web"
+)
+
+// CognitoClaims represents the Cognito user claims from API Gateway authorizer
+type CognitoClaims struct {
+	Sub           string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified string `json:"email_verified"`
+	Groups        string `json:"cognito:groups"`
+}
+
+// Handler is the Lambda entry point for API Gateway proxy integration
+func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// Extract Cognito claims from requestContext.authorizer.claims
+	var claims CognitoClaims
+	if authorizerData, exists := request.RequestContext.Authorizer["claims"]; exists {
+		if claimsMap, ok := authorizerData.(map[string]interface{}); ok {
+			// Convert claims to JSON and back to struct for type safety
+			claimsBytes, _ := json.Marshal(claimsMap)
+			json.Unmarshal(claimsBytes, &claims)
+		}
+	}
+
+	// Convert Lambda event to HTTP request
+	httpRequest := convertLambdaEventToHTTPRequest(request, claims)
+
+	// Initialize Beego application if not already done
+	web.BConfig.RunMode = "prod"
+	web.BConfig.CopyRequestBody = true
+
+	// Create a custom response writer to capture the response
+	responseWriter := &lambdaResponseWriter{
+		headers:    make(http.Header),
+		statusCode: http.StatusOK,
+	}
+
+	// Process the request through Beego
+	web.BeeApp.Handlers.ServeHTTP(responseWriter, httpRequest)
+
+	// Convert HTTP response to Lambda response
+	return convertHTTPResponseToLambdaResponse(responseWriter), nil
+}
+
+// convertLambdaEventToHTTPRequest converts API Gateway proxy request to HTTP request
+func convertLambdaEventToHTTPRequest(request events.APIGatewayProxyRequest, claims CognitoClaims) *http.Request {
+	// Build URL
+	path := request.Path
+	if request.PathParameters != nil {
+		for key, value := range request.PathParameters {
+			path = strings.ReplaceAll(path, "{"+key+"}", value)
+		}
+	}
+
+	// Add query parameters
+	values := url.Values{}
+	if request.QueryStringParameters != nil {
+		for key, value := range request.QueryStringParameters {
+			values.Add(key, value)
+		}
+	}
+
+	// Build full URL
+	fullURL := "https://" + request.Headers["Host"] + path
+	if len(values) > 0 {
+		fullURL += "?" + values.Encode()
+	}
+
+	// Create HTTP request
+	httpRequest, _ := http.NewRequest(request.HTTPMethod, fullURL, strings.NewReader(request.Body))
+
+	// Copy headers
+	for key, value := range request.Headers {
+		httpRequest.Header.Set(key, value)
+	}
+
+	// Add Cognito claims as custom headers for Beego
+	if claims.Sub != "" {
+		httpRequest.Header.Set("X-Cognito-Sub", claims.Sub)
+	}
+	if claims.Email != "" {
+		httpRequest.Header.Set("X-Cognito-Email", claims.Email)
+	}
+	if claims.EmailVerified != "" {
+		httpRequest.Header.Set("X-Cognito-Email-Verified", claims.EmailVerified)
+	}
+	if claims.Groups != "" {
+		httpRequest.Header.Set("X-Cognito-Groups", claims.Groups)
+	}
+
+	// Add AWS Lambda Proxy integration standard headers
+	if claims.Sub != "" {
+		httpRequest.Header.Set("X-Amzn-Cognito-Sub", claims.Sub)
+	}
+
+	return httpRequest
+}
+
+// lambdaResponseWriter implements http.ResponseWriter for capturing Beego responses
+type lambdaResponseWriter struct {
+	headers    http.Header
+	body       []byte
+	statusCode int
+}
+
+func (w *lambdaResponseWriter) Header() http.Header {
+	return w.headers
+}
+
+func (w *lambdaResponseWriter) Write(body []byte) (int, error) {
+	w.body = append(w.body, body...)
+	return len(body), nil
+}
+
+func (w *lambdaResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+// convertHTTPResponseToLambdaResponse converts HTTP response to API Gateway proxy response
+func convertHTTPResponseToLambdaResponse(w *lambdaResponseWriter) events.APIGatewayProxyResponse {
+	// Convert headers to string map
+	headers := make(map[string]string)
+	for key, values := range w.headers {
+		if len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
+
+	// Ensure CORS headers are present
+	headers["Access-Control-Allow-Origin"] = "*"
+	headers["Access-Control-Allow-Headers"] = "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token"
+	headers["Access-Control-Allow-Methods"] = "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT"
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: w.statusCode,
+		Headers:    headers,
+		Body:       string(w.body),
+	}
+}
+
+// Start starts the Lambda handler
+func Start() {
+	lambda.Start(Handler)
+}

--- a/back/main.go
+++ b/back/main.go
@@ -1,22 +1,17 @@
 package main
 
 import (
-	"context"
 	"mybeerlog/controllers"
+	"mybeerlog/lambda"
 	"mybeerlog/models"
 	"mybeerlog/utils"
 	"os"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/orm"
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
 
 	_ "github.com/lib/pq"
 )
-
-var beegoLambda *httpadapter.HandlerAdapter
 
 func init() {
 	// Lambda 環境変数からデータベース設定を取得
@@ -52,9 +47,6 @@ func init() {
 
 	// ルーティング設定
 	setupRoutes()
-
-	// Lambda adapter を初期化
-	beegoLambda = httpadapter.New(beego.BeeApp.Handlers)
 }
 
 // setupMiddleware ミドルウェアを設定する
@@ -93,11 +85,6 @@ func setupRoutes() {
 	beego.Router("/visits/:visit_id", visitController, "get:GetVisit")
 }
 
-// Handler Lambda ハンドラー関数
-func Handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	// API Gateway プロキシ統合を使用してリクエストを処理
-	return beegoLambda.ProxyWithContext(ctx, req)
-}
 
 // getEnvOrDefault 環境変数を取得し、存在しない場合はデフォルト値を返す
 func getEnvOrDefault(key, defaultValue string) string {
@@ -110,8 +97,8 @@ func getEnvOrDefault(key, defaultValue string) string {
 func main() {
 	// Lambda 環境かどうかをチェック
 	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
-		// Lambda 環境で実行
-		lambda.Start(Handler)
+		// Lambda 環境で実行（新しいLambda Handlerを使用）
+		lambda.Start()
 	} else {
 		// ローカル開発環境で実行
 		utils.Logger.Info("Running in local development mode")

--- a/infra/beerlog_template.yml
+++ b/infra/beerlog_template.yml
@@ -455,6 +455,17 @@ Resources:
         - Key: Environment
           Value: !Ref Environment
 
+  # Cognito Authorizer
+  BeerLogApiAuthorizer:
+    Type: AWS::ApiGateway::Authorizer
+    Properties:
+      Name: !Sub BeerLog-${Environment}-CognitoAuthorizer
+      Type: COGNITO_USER_POOLS
+      IdentitySource: method.request.header.Authorization
+      RestApiId: !Ref BeerLogApiGateway
+      ProviderARNs:
+        - !GetAtt BeerLogCognitoUserPool.Arn
+
   BeerLogApiDeployment:
     Type: AWS::ApiGateway::Deployment
     DependsOn: BeerLogApiMethod
@@ -488,7 +499,8 @@ Resources:
       RestApiId: !Ref BeerLogApiGateway
       ResourceId: !Ref BeerLogApiResource
       HttpMethod: ANY
-      AuthorizationType: NONE
+      AuthorizationType: COGNITO_USER_POOLS
+      AuthorizerId: !Ref BeerLogApiAuthorizer
       Integration:
         IntegrationHttpMethod: POST
         Type: AWS_PROXY


### PR DESCRIPTION
## 概要

issue #4 で設計されたCognito Sub取得処理改修を実装しました。

## 変更内容

### 1. CloudFormation修正
- **Cognito Authorizerの追加**: API Gateway用のCognito User Pool認証を追加
- **AuthorizationTypeの修正**: `NONE` から `COGNITO_USER_POOLS` に変更

### 2. Lambda Handler実装 
- **新規作成**: `back/lambda/handler.go`
- **機能**: API Gateway requestContextからCognito claimsを抽出し、HTTPヘッダーに変換
- **対応ヘッダー**: `X-Cognito-Sub`, `X-Amzn-Cognito-Sub`, `X-Cognito-Email`, `X-Cognito-Groups`

### 3. main.go修正
- **Lambda環境分岐**: 新しいLambda Handlerを使用するよう修正
- **後方互換性**: 既存のローカル開発環境との互換性を維持

## 技術詳細

### 認証フロー
```
1. フロントエンド → API Gateway (Cognito JWT トークン)
2. API Gateway → Cognito Authorizer (JWT検証)
3. API Gateway → Lambda (requestContext.authorizer.claims付き)
4. Lambda Handler → HTTP Headers変換 (X-Cognito-Sub等)
5. Beego Controller → 既存のgetCognitoSubFromHeaders()で正常取得
```

### 既存コードとの互換性
- BaseControllerの`getCognitoSubFromHeaders()`は既に対応ヘッダーをサポート
- 開発環境でのテスト認証機能は引き続き動作
- ローカル開発環境は従来通りの動作を維持

## テスト

### 期待される動作
- Lambda環境でCognito認証済みリクエストから正しくSubを取得
- 開発環境では既存のテスト認証機能が継続動作
- API Gateway Authorizer による自動的なJWT検証

### 動作確認項目
- [ ] CloudFormationテンプレートのデプロイ成功
- [ ] Lambda関数のデプロイと起動
- [ ] Cognito認証フローの正常動作
- [ ] 既存APIエンドポイントでの認証情報取得

## 関連Issue

Closes #4

## 影響範囲

- **インフラ**: CloudFormationテンプレート（Cognito Authorizer追加）
- **バックエンド**: Lambda統合アーキテクチャ
- **既存機能**: 影響なし（後方互換性維持）

---

この実装により、API Gateway Lambda プロキシ統合でのCognito認証情報取得が正常に動作するようになります。