### PR TITLE
feat: CognitoSub取得処理改修 - AWS API Gateway Cognito Authorizer対応

### DIFF
--- a/back/controllers/base.go
+++ b/back/controllers/base.go
@@ -137,28 +137,46 @@ func (c *BaseController) GetCognitoSub() (string, error) {
 
 // getCognitoSubFromHeaders API Gatewayが設定する各種ヘッダーからCognito Subを取得
 func (c *BaseController) getCognitoSubFromHeaders() string {
-	// API Gateway Cognito Authorizer が設定するヘッダー（一般的なパターン）
+	// 1. Lambda Handler層でrequestContext.authorizer.claimsから変換されたヘッダー（最優先）
+	if value := c.Ctx.Request.Header.Get("X-Cognito-Sub"); value != "" {
+		utils.LogDebug(c.Ctx.Request.Context(), "Cognito Sub found in X-Cognito-Sub header", map[string]interface{}{
+			"source": "lambda_handler_enrichment",
+			"cognito_sub": value,
+		})
+		return value
+	}
+
+	// 2. その他のAPI Gateway Cognito Authorizer が設定する可能性のあるヘッダー
 	headers := []string{
-		"X-Cognito-Sub",      // Cognito Authorizer
-		"X-Amzn-Cognito-Sub", // AWS Lambda Proxy統合
+		"X-Amzn-Cognito-Sub", // AWS Lambda Proxy統合（直接設定される場合）
 		"X-Amz-User-Sub",     // カスタムヘッダー
 		"X-User-Sub",         // カスタムヘッダー
 	}
 
 	for _, header := range headers {
 		if value := c.Ctx.Request.Header.Get(header); value != "" {
+			utils.LogDebug(c.Ctx.Request.Context(), "Cognito Sub found in fallback header", map[string]interface{}{
+				"source": "fallback_header",
+				"header": header,
+				"cognito_sub": value,
+			})
 			return value
 		}
 	}
 
-	// Lambda環境での requestContext からの取得（追加の確認）
+	// 3. Lambda環境での requestContext からの取得（レガシー対応）
 	if c.Ctx.Request.Header.Get("X-Amzn-Requestid") != "" {
 		// API Gateway Lambda プロキシ統合でのリクエストコンテキスト情報
 		if value := c.Ctx.Request.Header.Get("X-Amzn-Requestcontext-Authorizer-Claims-Sub"); value != "" {
+			utils.LogDebug(c.Ctx.Request.Context(), "Cognito Sub found in legacy requestcontext header", map[string]interface{}{
+				"source": "legacy_requestcontext",
+				"cognito_sub": value,
+			})
 			return value
 		}
 	}
 
+	utils.LogWarn(c.Ctx.Request.Context(), "Cognito Sub not found in any expected headers")
 	return ""
 }
 

--- a/back/main.go
+++ b/back/main.go
@@ -95,8 +95,54 @@ func setupRoutes() {
 
 // Handler Lambda ハンドラー関数
 func Handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// Cognito認証情報をヘッダーに変換
+	enrichedRequest := enrichRequestWithCognitoInfo(req)
+	
 	// API Gateway プロキシ統合を使用してリクエストを処理
-	return beegoLambda.ProxyWithContext(ctx, req)
+	return beegoLambda.ProxyWithContext(ctx, enrichedRequest)
+}
+
+// enrichRequestWithCognitoInfo API Gateway ProxyRequestからCognito認証情報を抽出してヘッダーに追加
+func enrichRequestWithCognitoInfo(req events.APIGatewayProxyRequest) events.APIGatewayProxyRequest {
+	// リクエストのヘッダーマップを初期化（存在しない場合）
+	if req.Headers == nil {
+		req.Headers = make(map[string]string)
+	}
+	
+	// API Gateway Cognito Authorizerから認証情報を取得
+	if req.RequestContext.Authorizer != nil {
+		// Authorizerのclaims情報からCognito Subを取得
+		if claims, ok := req.RequestContext.Authorizer["claims"].(map[string]interface{}); ok {
+			// Cognito Subを取得
+			if sub, exists := claims["sub"]; exists {
+				if subStr, ok := sub.(string); ok && subStr != "" {
+					req.Headers["X-Cognito-Sub"] = subStr
+					utils.Logger.WithField("cognito_sub", subStr).Debug("Cognito Sub extracted from requestContext.authorizer.claims")
+				}
+			}
+			
+			// Cognito グループ情報を取得（存在する場合）
+			if groups, exists := claims["cognito:groups"]; exists {
+				if groupsStr, ok := groups.(string); ok && groupsStr != "" {
+					req.Headers["X-Cognito-Groups"] = groupsStr
+					utils.Logger.WithField("cognito_groups", groupsStr).Debug("Cognito Groups extracted from requestContext.authorizer.claims")
+				}
+			}
+			
+			// その他のCognitoクレーム情報も必要に応じて追加
+			if email, exists := claims["email"]; exists {
+				if emailStr, ok := email.(string); ok && emailStr != "" {
+					req.Headers["X-Cognito-Email"] = emailStr
+				}
+			}
+		} else {
+			utils.Logger.Warn("requestContext.authorizer.claims not found or invalid format")
+		}
+	} else {
+		utils.Logger.Warn("requestContext.authorizer not found - authentication may not be enabled")
+	}
+	
+	return req
 }
 
 // getEnvOrDefault 環境変数を取得し、存在しない場合はデフォルト値を返す

--- a/infra/beerlog_template.yml
+++ b/infra/beerlog_template.yml
@@ -443,6 +443,17 @@ Resources:
         - Key: Environment
           Value: !Ref Environment
 
+  # Cognito Authorizer
+  BeerLogApiAuthorizer:
+    Type: AWS::ApiGateway::Authorizer
+    Properties:
+      Name: !Sub BeerLog-${Environment}-CognitoAuthorizer
+      Type: COGNITO_USER_POOLS
+      IdentitySource: method.request.header.Authorization
+      RestApiId: !Ref BeerLogApiGateway
+      ProviderARNs:
+        - !GetAtt BeerLogCognitoUserPool.Arn
+
   # API Gateway
   BeerLogApiGateway:
     Type: AWS::ApiGateway::RestApi
@@ -488,7 +499,8 @@ Resources:
       RestApiId: !Ref BeerLogApiGateway
       ResourceId: !Ref BeerLogApiResource
       HttpMethod: ANY
-      AuthorizationType: NONE
+      AuthorizationType: COGNITO_USER_POOLS
+      AuthorizerId: !Ref BeerLogApiAuthorizer
       Integration:
         IntegrationHttpMethod: POST
         Type: AWS_PROXY


### PR DESCRIPTION
## Summary

Issue #4で指摘されたCognitoSub取得処理の根本的な問題を解決しました。

### 実装内容

**🔧 CloudFormationテンプレート修正**
- Cognito Authorizerリソースを追加
- API Gateway MethodでCognito認証を有効化（`AuthorizationType: COGNITO_USER_POOLS`）

**⚙️ Lambda Handler層改修**
- `enrichRequestWithCognitoInfo()`関数を新規実装
- `requestContext.authorizer.claims`からCognito認証情報を抽出
- HTTPヘッダー（`X-Cognito-Sub`等）に変換してBeegoアプリに渡す

**📝 BaseController調整**
- `getCognitoSubFromHeaders()`メソッドを最適化
- Lambda Handler層から変換されたヘッダーを最優先で処理
- 詳細なログ出力で認証情報の取得元を追跡可能

### 動作フロー

```
フロントエンド → API Gateway (Cognito JWT) → Cognito Authorizer (JWT検証) → Lambda (requestContext.authorizer.claims) → enrichRequestWithCognitoInfo() → Beego BaseController.getCognitoSubFromHeaders()
```

### テスト計画

- [ ] CloudFormationスタックのデプロイ確認
- [ ] Cognito認証が有効になることの確認  
- [ ] Lambda Handler層でのCognito情報抽出の確認
- [ ] BaseControllerでの認証情報取得の確認
- [ ] 開発環境でのテストトークン機能との互換性確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #4