### PR TITLE
APIGateway Cognito オーソライザーを設定

### DIFF
--- a/infra/beerlog_template.yml
+++ b/infra/beerlog_template.yml
@@ -457,7 +457,9 @@ Resources:
 
   BeerLogApiDeployment:
     Type: AWS::ApiGateway::Deployment
-    DependsOn: BeerLogApiMethod
+    DependsOn: 
+      - BeerLogApiMethod
+      - BeerLogApiAuthorizer
     Properties:
       RestApiId: !Ref BeerLogApiGateway
       StageName: v1 # ダミー（ステージリソースで上書き）
@@ -482,13 +484,25 @@ Resources:
       ParentId: !GetAtt BeerLogApiGateway.RootResourceId
       PathPart: '{proxy+}'
 
+  # Cognito Authorizer
+  BeerLogApiAuthorizer:
+    Type: AWS::ApiGateway::Authorizer
+    Properties:
+      Name: !Sub BeerLog-${Environment}-CognitoAuthorizer
+      Type: COGNITO_USER_POOLS
+      IdentitySource: method.request.header.Authorization
+      RestApiId: !Ref BeerLogApiGateway
+      ProviderARNs:
+        - !GetAtt BeerLogCognitoUserPool.Arn
+
   BeerLogApiMethod:
     Type: AWS::ApiGateway::Method
     Properties:
       RestApiId: !Ref BeerLogApiGateway
       ResourceId: !Ref BeerLogApiResource
       HttpMethod: ANY
-      AuthorizationType: NONE
+      AuthorizationType: COGNITO_USER_POOLS
+      AuthorizerId: !Ref BeerLogApiAuthorizer
       Integration:
         IntegrationHttpMethod: POST
         Type: AWS_PROXY
@@ -628,3 +642,9 @@ Outputs:
     Value: !Ref BeerLogLambdaFunction
     Export:
       Name: !Sub ${AWS::StackName}-LambdaFunctionName
+
+  ApiAuthorizer:
+    Description: API Gateway Cognito Authorizer ID
+    Value: !Ref BeerLogApiAuthorizer
+    Export:
+      Name: !Sub ${AWS::StackName}-ApiAuthorizer


### PR DESCRIPTION
## 概要
issue #19 の対応として、API Gateway に Cognito User Pools オーソライザーを設定しました。

## 変更内容
- **BeerLogApiAuthorizer** リソースを追加
  - Type: `COGNITO_USER_POOLS`
  - IdentitySource: `method.request.header.Authorization`
  - ProviderARNs: 既存の BeerLogCognitoUserPool を参照

- **BeerLogApiMethod** の認証設定を更新
  - AuthorizationType を `NONE` から `COGNITO_USER_POOLS` に変更
  - AuthorizerId を追加

- **BeerLogApiDeployment** の依存関係を更新
  - DependsOn に BeerLogApiAuthorizer を追加

- **出力値の追加**
  - ApiAuthorizer: デバッグ・管理用の出力値

## 技術仕様
- AWS ベストプラクティスに準拠
- 環境別設定対応（`${Environment}` パラメータ使用）
- 既存のバックエンド実装との完全互換性

## バックエンド連携
既存の Go バックエンド実装は変更不要です。以下の実装により API Gateway Cognito Authorizer と完全に互換性があります：

- `BaseController.GetCognitoSub()`: Cognito Authorizer が設定するヘッダーを取得
- `BaseController.getCognitoSubFromHeaders()`: 標準的な Authorizer ヘッダーパターンに対応
- 認証エラーハンドリング: 統一エラーレスポンス対応済み

## セキュリティ向上
この変更により、すべての API エンドポイントが Cognito User Pool による認証が必要となり、セキュリティが向上します。

Fixes #19