### PR TITLE
Fix fetchNearbyBreweries endpoint and parameters

### DIFF
--- a/front/src/hooks/useBreweries.ts
+++ b/front/src/hooks/useBreweries.ts
@@ -175,13 +175,13 @@ export function useBreweries() {
           limit: options?.limit || breweryState?.filters?.limit || 20,
         };
 
-        const response = await apiClientRef.current.get<{
-          breweries: Brewery[];
-          total: number;
-        }>('/breweries', params);
+        const response = await apiClientRef.current.get<ApiResponse<Brewery[]>>(
+          '/breweries',
+          params
+        );
 
         // Calculate distances and sort by distance
-        const breweriesWithDistance: BreweryWithDistance[] = response.data.breweries
+        const breweriesWithDistance: BreweryWithDistance[] = response.data
           .map((brewery: Brewery) => ({
             ...brewery,
             distance: calculateDistance(userLocation, {

--- a/front/src/hooks/useBreweries.ts
+++ b/front/src/hooks/useBreweries.ts
@@ -169,19 +169,19 @@ export function useBreweries() {
         dispatch(clearError());
 
         const params: Record<string, string | number> = {
-          latitude: userLocation.latitude,
-          longitude: userLocation.longitude,
+          lat: userLocation.latitude,
+          lng: userLocation.longitude,
           radius: options?.radius || breweryState?.filters?.radius || 5,
           limit: options?.limit || breweryState?.filters?.limit || 20,
         };
 
-        const response = await apiClientRef.current.get<ApiResponse<Brewery[]>>(
-          '/breweries/nearby',
-          params
-        );
+        const response = await apiClientRef.current.get<{
+          breweries: Brewery[];
+          total: number;
+        }>('/breweries', params);
 
         // Calculate distances and sort by distance
-        const breweriesWithDistance: BreweryWithDistance[] = response.data
+        const breweriesWithDistance: BreweryWithDistance[] = response.data.breweries
           .map((brewery: Brewery) => ({
             ...brewery,
             distance: calculateDistance(userLocation, {


### PR DESCRIPTION
## 概要
存在しない`/breweries/nearby`エンドポイントへのコールを修正し、正しい`GET /breweries`エンドポイントを使用するようにしました。

## 変更内容

### `front/src/hooks/useBreweries.ts` の `fetchNearbyBreweries` メソッド修正

1. **エンドポイントの変更**
   - 変更前: `/breweries/nearby` (存在しないエンドポイント)
   - 変更後: `/breweries` (実際に実装されているエンドポイント)

2. **パラメータ名の修正**
   - `latitude` → `lat`
   - `longitude` → `lng`
   - `radius`, `limit` はそのまま維持

3. **レスポンス形式の修正**
   - 変更前: `ApiResponse<Brewery[]>` で `response.data` に直接アクセス
   - 変更後: `{ breweries: Brewery[], total: number }` で `response.data.breweries` にアクセス

## 影響範囲
- `fetchNearbyBreweries` メソッドのみが対象
- 他の API 呼び出し（`fetchBreweries`, `searchBreweries` 等）への影響なし
- 距離計算とソート機能は従来通り動作

## テスト
- OpenAPI 仕様（`docs/api/openapi.yml`）との整合性確認済み
- API の実装仕様に合致

## 解決する Issue
Closes #5

---

この修正により、フロントエンドから存在しないエンドポイントへのコールが解消され、正しいバックエンド API を使用した近隣醸造所の取得が可能になります。