### PR TITLE
fix: フロントエンドAPIクライアントの認証ヘッダー修正 #22

### DIFF
--- a/front/__tests__/lib/api/client.test.ts
+++ b/front/__tests__/lib/api/client.test.ts
@@ -47,14 +47,14 @@ describe('ApiClient', () => {
     });
   });
 
-  describe('setAccessToken', () => {
-    it('sets access token', () => {
-      apiClient.setAccessToken('test-token');
+  describe('setIdToken', () => {
+    it('sets ID token', () => {
+      apiClient.setIdToken('test-token');
       // The token will be tested through requests
     });
 
     it('handles null token', () => {
-      apiClient.setAccessToken(null);
+      apiClient.setIdToken(null);
       // Should not throw
     });
   });
@@ -99,7 +99,7 @@ describe('ApiClient', () => {
 
     it('includes authorization header when token is set', async () => {
       const token = 'test-token';
-      apiClient.setAccessToken(token);
+      apiClient.setIdToken(token);
 
       (fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
@@ -113,7 +113,7 @@ describe('ApiClient', () => {
         'https://api.test.com/test',
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: `Bearer ${token}`,
+            Authorization: token,
           }),
         })
       );

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -102,7 +102,7 @@ export function useAuth() {
 
           if (tokens.accessToken && tokens.idToken) {
             // Set API client token
-            apiClient.setAccessToken(tokens.accessToken);
+            apiClient.setIdToken(tokens.accessToken);
 
             dispatch(
               loginSuccess({
@@ -311,7 +311,7 @@ export function useAuth() {
       await cognitoAuthService.logout();
 
       // Clear API client token
-      apiClient.setAccessToken(null);
+      apiClient.setIdToken(null);
 
       dispatch(logoutAction());
     } catch (error) {
@@ -340,7 +340,7 @@ export function useAuth() {
 
         if (tokens.accessToken && tokens.idToken) {
           // Set API client token
-          apiClient.setAccessToken(tokens.accessToken);
+          apiClient.setIdToken(tokens.accessToken);
 
           dispatch(
             updateTokens({

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -102,7 +102,7 @@ export function useAuth() {
 
           if (tokens.accessToken && tokens.idToken) {
             // Set API client token
-            apiClient.setIdToken(tokens.accessToken);
+            apiClient.setIdToken(tokens.idToken);
 
             dispatch(
               loginSuccess({
@@ -340,7 +340,7 @@ export function useAuth() {
 
         if (tokens.accessToken && tokens.idToken) {
           // Set API client token
-          apiClient.setIdToken(tokens.accessToken);
+          apiClient.setIdToken(tokens.idToken);
 
           dispatch(
             updateTokens({

--- a/front/src/lib/api/client.ts
+++ b/front/src/lib/api/client.ts
@@ -25,7 +25,7 @@ import { API_CONFIG, HTTP_STATUS, ERROR_MESSAGES } from '../constants';
  * });
  *
  * // 認証トークンの設定
- * client.setAccessToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+ * client.setIdToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
  *
  * // GET リクエスト
  * const breweries = await client.get<Brewery[]>('/breweries');
@@ -61,7 +61,7 @@ export class ApiClient {
    * // カスタム設定でクライアントを作成
    * const client = new ApiClient({
    *   baseUrl: 'https://api.example.com',
-   *   accessToken: 'your-jwt-token'
+   *   idToken: 'your-jwt-token'
    * });
    * ```
    */
@@ -77,19 +77,19 @@ export class ApiClient {
    *
    * @description 以降のすべてのAPIリクエストでJWT認証ヘッダーとして使用されます。
    *
-   * @param token - JWT アクセストークン（null の場合は認証ヘッダーを削除）
+   * @param token - JWT IDトークン（null の場合は認証ヘッダーを削除）
    *
    * @example
    * ```typescript
    * // トークンを設定
-   * client.setAccessToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+   * client.setIdToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
    *
    * // トークンを削除（ログアウト時など）
-   * client.setAccessToken(null);
+   * client.setIdToken(null);
    * ```
    */
-  setAccessToken(token: string | null) {
-    this.config.accessToken = token || undefined;
+  setIdToken(token: string | null) {
+    this.config.idToken = token || undefined;
   }
 
   /**
@@ -121,8 +121,8 @@ export class ApiClient {
       ...config.headers,
     };
 
-    if (this.config.accessToken) {
-      headers.Authorization = `Bearer ${this.config.accessToken}`;
+    if (this.config.idToken) {
+      headers.Authorization = this.config.idToken;
     }
 
     const requestInit: RequestInit = {
@@ -341,7 +341,7 @@ export class ApiClient {
  * const breweries = await apiClient.get<Brewery[]>('/breweries');
  *
  * // 認証が必要な場合はトークンを設定
- * apiClient.setAccessToken(accessToken);
+ * apiClient.setIdToken(idToken);
  * const profile = await apiClient.get<UserProfile>('/profile');
  * ```
  */

--- a/front/src/types/api.ts
+++ b/front/src/types/api.ts
@@ -333,15 +333,15 @@ export interface PaginatedResponse<T> {
  * ```typescript
  * const config: ApiClientConfig = {
  *   baseUrl: "https://api.mybeerlog.com",
- *   accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *   idToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  * };
  * ```
  */
 export interface ApiClientConfig {
   /** APIのベースURL（例: "https://api.mybeerlog.com"） */
   baseUrl: string;
-  /** 認証用のアクセストークン（JWT形式、任意） */
-  accessToken?: string;
+  /** 認証用のIDトークン（JWT形式、任意） */
+  idToken?: string;
 }
 
 /**


### PR DESCRIPTION
## 概要

Issue #22 で報告されたフロントエンドAPIクライアントの認証情報の誤りを修正しました。
AWS API Gateway Cognito Authorizerの仕様に適合するよう、認証ヘッダーの形式を正しく設定しました。

## 変更内容

### 🔧 認証トークンの種類変更
- **変更前**: Access Token使用
- **変更後**: ID Token使用（AWS Cognito認証仕様に準拠）

### 🔧 Authorization ヘッダー形式修正  
- **変更前**: `Authorization: Bearer {accessToken}`
- **変更後**: `Authorization: {idToken}` (Bearerプレフィックス削除)

### 🔧 APIインターフェース更新
- `setAccessToken()` → `setIdToken()` メソッド名変更
- `ApiClientConfig.accessToken` → `ApiClientConfig.idToken` プロパティ名変更
- 対応するJSDocコメントとサンプルコードの更新

### 🔧 テストファイル修正
- テストケースをID Token使用に更新
- Bearerプレフィックスなしの認証ヘッダー検証に変更

## 影響ファイル
- `front/src/types/api.ts` - 型定義更新
- `front/src/lib/api/client.ts` - APIクライアント実装修正
- `front/__tests__/lib/api/client.test.ts` - テスト修正

## 検証
- AWS API Gateway Cognito Authorizerとの認証連携が正常動作
- 既存のAPI呼び出しパターンは新しいメソッド名で同様に機能

## AWS Cognito JWT トークンの仕組み

### Access Token vs ID Token の違い
- **Access Token**: APIのリソースアクセス権限を表す（通常はRS256署名）
- **ID Token**: ユーザー認証情報を含む（ユーザー属性、認証状態を含む）
- **AWS API Gateway Cognito Authorizer**: ID Tokenを使用してユーザー認証を行う

### API Gateway Cognito Authorizerの期待する形式
```
Authorization: eyJraWQiOiJZWjFHVU1...（ID Token直接、Bearerプレフィックスなし）
```

Resolves #22