### PR TITLE
初回ログイン時にユーザプロフィールを作成する機能を実装

### DIFF
--- a/front/src/app/auth/login/page.tsx
+++ b/front/src/app/auth/login/page.tsx
@@ -15,18 +15,25 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import ProfileSetupForm from '@/components/user/ProfileSetupForm';
+import { userProfileApi } from '@/lib/api/user';
 import { ROUTES, VALIDATION } from '@/lib/constants';
 import type { LoginCredentials } from '@/types/auth';
+import type { ProfileCreateForm } from '@/types/user';
+
+type PageState = 'login' | 'profile-setup' | 'redirecting';
 
 export default function LoginPage() {
   const router = useRouter();
   const { login, authState } = useAuthContext();
+  const [pageState, setPageState] = useState<PageState>('login');
   const [formData, setFormData] = useState<LoginCredentials>({
     email: '',
     password: '',
   });
   const [errors, setErrors] = useState<Partial<LoginCredentials>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
 
   // Redirect to home if already logged in
   useEffect(() => {
@@ -34,6 +41,69 @@ export default function LoginPage() {
       router.push(ROUTES.home);
     }
   }, [authState, router]);
+
+  /**
+   * プロフィール存在確認処理
+   *
+   * @description ログイン成功後にプロフィールの存在を確認し、
+   * 存在しない場合はプロフィール作成画面を表示する
+   */
+  const checkUserProfile = async (): Promise<void> => {
+    try {
+      // プロフィール存在確認
+      await userProfileApi.getProfile();
+      
+      // プロフィールが存在する場合はホームページへリダイレクト
+      setPageState('redirecting');
+      router.push(ROUTES.home);
+    } catch (error: any) {
+      if (error?.status === 404) {
+        // プロフィールが存在しない場合はプロフィール作成画面へ
+        setPageState('profile-setup');
+      } else {
+        // その他のエラーの場合
+        console.error('プロフィール確認エラー:', error);
+        setProfileError(
+          'プロフィール情報の確認に失敗しました。再度ログインしてください。'
+        );
+        // エラー時はログイン画面に戻る
+        setPageState('login');
+      }
+    }
+  };
+
+  /**
+   * プロフィール作成処理
+   *
+   * @param profileData - 作成するプロフィールデータ
+   */
+  const handleProfileCreate = async (
+    profileData: ProfileCreateForm
+  ): Promise<void> => {
+    try {
+      setProfileError(null);
+      
+      // プロフィール作成
+      await userProfileApi.createProfile(profileData);
+      
+      // 作成成功後、ホームページへリダイレクト
+      setPageState('redirecting');
+      router.push(ROUTES.home);
+    } catch (error: any) {
+      console.error('プロフィール作成エラー:', error);
+      
+      if (error?.status === 409) {
+        setProfileError('プロフィールが既に存在します。');
+        // 既存の場合はホームページへリダイレクト
+        setPageState('redirecting');
+        router.push(ROUTES.home);
+      } else {
+        setProfileError(
+          error?.message || 'プロフィールの作成に失敗しました。'
+        );
+      }
+    }
+  };
 
   const validateForm = (): boolean => {
     const newErrors: Partial<LoginCredentials> = {};
@@ -62,9 +132,14 @@ export default function LoginPage() {
     }
 
     setIsSubmitting(true);
+    setProfileError(null);
+    
     try {
+      // ログイン実行
       await login(formData);
-      router.push(ROUTES.home);
+      
+      // ログイン成功後、プロフィール存在確認
+      await checkUserProfile();
     } catch (error) {
       console.error('Login failed:', error);
     } finally {
@@ -82,8 +157,19 @@ export default function LoginPage() {
     }
   };
 
-  // Show redirect message if already authenticated
-  if (authState.isAuthenticated && !authState.isLoading) {
+  // プロフィール作成画面を表示
+  if (pageState === 'profile-setup') {
+    return (
+      <ProfileSetupForm
+        onSubmit={handleProfileCreate}
+        isSubmitting={isSubmitting}
+        error={profileError}
+      />
+    );
+  }
+
+  // リダイレクト中の表示
+  if (pageState === 'redirecting' || (authState.isAuthenticated && !authState.isLoading)) {
     return (
       <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
         <div className='max-w-md w-full space-y-8'>
@@ -101,6 +187,7 @@ export default function LoginPage() {
     );
   }
 
+  // ログイン画面の表示
   return (
     <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
       <div className='max-w-md w-full space-y-8'>
@@ -149,9 +236,11 @@ export default function LoginPage() {
                 )}
               </div>
 
-              {authState.error && (
+              {(authState.error || profileError) && (
                 <div className='bg-red-50 border border-red-200 rounded-md p-3'>
-                  <p className='text-sm text-red-600'>{authState.error}</p>
+                  <p className='text-sm text-red-600'>
+                    {authState.error || profileError}
+                  </p>
                 </div>
               )}
 

--- a/front/src/components/user/ProfileSetupForm.tsx
+++ b/front/src/components/user/ProfileSetupForm.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ProfileCreateForm } from '@/types/user';
+
+interface ProfileSetupFormProps {
+  onSubmit: (formData: ProfileCreateForm) => Promise<void>;
+  isSubmitting: boolean;
+  error?: string | null;
+}
+
+/**
+ * プロフィール初期設定フォーム
+ *
+ * @description 初回ログイン時にユーザープロフィールを作成するためのフォームコンポーネントです。
+ * 現在の実装では表示名（display_name）のみを入力します。
+ *
+ * @param props - フォームのプロパティ
+ * @param props.onSubmit - フォーム送信時のハンドラー
+ * @param props.isSubmitting - 送信中フラグ
+ * @param props.error - エラーメッセージ
+ *
+ * @example
+ * ```tsx
+ * const handleProfileCreate = async (formData: ProfileCreateForm) => {
+ *   try {
+ *     await userProfileApi.createProfile(formData);
+ *     router.push('/');
+ *   } catch (error) {
+ *     console.error('プロフィール作成エラー:', error);
+ *   }
+ * };
+ *
+ * <ProfileSetupForm
+ *   onSubmit={handleProfileCreate}
+ *   isSubmitting={isSubmitting}
+ *   error={error}
+ * />
+ * ```
+ */
+export default function ProfileSetupForm({
+  onSubmit,
+  isSubmitting,
+  error,
+}: ProfileSetupFormProps) {
+  const [formData, setFormData] = useState<ProfileCreateForm>({
+    display_name: '',
+  });
+  const [formErrors, setFormErrors] = useState<
+    Partial<Record<keyof ProfileCreateForm, string>>
+  >({});
+
+  /**
+   * フォーム入力の妥当性を検証する
+   *
+   * @returns 妥当性チェック結果（true: 妥当、false: 不正）
+   */
+  const validateForm = (): boolean => {
+    const newErrors: Partial<Record<keyof ProfileCreateForm, string>> = {};
+
+    // 表示名のバリデーション
+    if (!formData.display_name.trim()) {
+      newErrors.display_name = '表示名は必須です';
+    } else if (formData.display_name.trim().length < 1) {
+      newErrors.display_name = '表示名は1文字以上で入力してください';
+    } else if (formData.display_name.trim().length > 50) {
+      newErrors.display_name = '表示名は50文字以内で入力してください';
+    }
+
+    setFormErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  /**
+   * フォーム送信ハンドラー
+   *
+   * @param e - フォームイベント
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    try {
+      await onSubmit({
+        display_name: formData.display_name.trim(),
+      });
+    } catch (error) {
+      console.error('プロフィール作成エラー:', error);
+    }
+  };
+
+  /**
+   * 入力フィールド変更ハンドラー
+   *
+   * @param e - 入力イベント
+   */
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+
+    // エラーがある場合、入力開始時にクリア
+    if (formErrors[name as keyof ProfileCreateForm]) {
+      setFormErrors(prev => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  return (
+    <div className='min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8'>
+      <div className='max-w-md w-full space-y-8'>
+        <Card>
+          <CardHeader className='space-y-1'>
+            <CardTitle className='text-2xl text-center'>
+              プロフィール設定
+            </CardTitle>
+            <CardDescription className='text-center'>
+              My Beer Logで使用する表示名を設定してください
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='display_name'>表示名</Label>
+                <Input
+                  id='display_name'
+                  name='display_name'
+                  type='text'
+                  required
+                  value={formData.display_name}
+                  onChange={handleInputChange}
+                  placeholder='例: 田中太郎'
+                  className={formErrors.display_name ? 'border-red-500' : ''}
+                  disabled={isSubmitting}
+                />
+                {formErrors.display_name && (
+                  <p className='text-sm text-red-600'>
+                    {formErrors.display_name}
+                  </p>
+                )}
+                <p className='text-sm text-gray-500'>
+                  ビール記録やレビューで表示される名前です。後から変更可能です。
+                </p>
+              </div>
+
+              {error && (
+                <div className='bg-red-50 border border-red-200 rounded-md p-3'>
+                  <p className='text-sm text-red-600'>{error}</p>
+                </div>
+              )}
+
+              <Button type='submit' className='w-full' disabled={isSubmitting}>
+                {isSubmitting ? 'プロフィール作成中...' : 'プロフィールを作成'}
+              </Button>
+            </form>
+
+            <div className='mt-6'>
+              <p className='text-center text-sm text-gray-500'>
+                プロフィール作成後、My Beer Logの利用を開始できます
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/front/src/lib/api/user.ts
+++ b/front/src/lib/api/user.ts
@@ -1,0 +1,104 @@
+/**
+ * User Profile API Client
+ *
+ * ユーザープロフィール関連のAPI呼び出し機能を提供します。
+ * バックエンドの `/users/profile` エンドポイントとの通信を担当します。
+ *
+ * @since v1.0.0
+ */
+
+import type { UserProfile, UserProfileInput } from '@/types/user';
+
+import { apiClient } from './client';
+
+/**
+ * ユーザープロフィール API クライアント
+ *
+ * @description ユーザープロフィールの取得、作成、更新機能を提供します。
+ * 認証が必要なエンドポイントなので、事前にAPIクライアントにJWTトークンが設定されている必要があります。
+ */
+export const userProfileApi = {
+  /**
+   * ユーザープロフィールを取得する
+   *
+   * @description 認証済みユーザーのプロフィール情報を取得します。
+   * プロフィールが存在しない場合は404エラーが返されます。
+   *
+   * @returns ユーザープロフィール情報
+   * @throws API呼び出しエラー（404: プロフィール未存在、401: 未認証）
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   const profile = await userProfileApi.getProfile();
+   *   console.log('プロフィール:', profile);
+   * } catch (error) {
+   *   if (error.status === 404) {
+   *     console.log('プロフィールが存在しません');
+   *   } else {
+   *     console.error('プロフィール取得エラー:', error);
+   *   }
+   * }
+   * ```
+   */
+  async getProfile(): Promise<UserProfile> {
+    return apiClient.get<UserProfile>('/users/profile');
+  },
+
+  /**
+   * ユーザープロフィールを作成する
+   *
+   * @description 新規ユーザーのプロフィールを作成します。
+   * プロフィールが既に存在する場合は409エラーが返されます。
+   *
+   * @param profileData - 作成するプロフィール情報
+   * @returns 作成されたユーザープロフィール情報
+   * @throws API呼び出しエラー（409: プロフィール既存在、400: 不正な入力、401: 未認証）
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   const newProfile = await userProfileApi.createProfile({
+   *     display_name: '田中太郎'
+   *   });
+   *   console.log('プロフィール作成成功:', newProfile);
+   * } catch (error) {
+   *   if (error.status === 409) {
+   *     console.log('プロフィールが既に存在します');
+   *   } else {
+   *     console.error('プロフィール作成エラー:', error);
+   *   }
+   * }
+   * ```
+   */
+  async createProfile(profileData: UserProfileInput): Promise<UserProfile> {
+    return apiClient.post<UserProfile>('/users/profile', profileData);
+  },
+
+  /**
+   * ユーザープロフィールを更新する
+   *
+   * @description 認証済みユーザーのプロフィール情報を更新します。
+   * プロフィールが存在しない場合は404エラーが返されます。
+   *
+   * @param profileData - 更新するプロフィール情報
+   * @returns 更新されたユーザープロフィール情報
+   * @throws API呼び出しエラー（404: プロフィール未存在、400: 不正な入力、401: 未認証）
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   const updatedProfile = await userProfileApi.updateProfile({
+   *     display_name: '田中次郎',
+   *     icon_url: 'https://example.com/new-avatar.jpg'
+   *   });
+   *   console.log('プロフィール更新成功:', updatedProfile);
+   * } catch (error) {
+   *   console.error('プロフィール更新エラー:', error);
+   * }
+   * ```
+   */
+  async updateProfile(profileData: UserProfileInput): Promise<UserProfile> {
+    return apiClient.put<UserProfile>('/users/profile', profileData);
+  },
+};

--- a/front/src/types/user.ts
+++ b/front/src/types/user.ts
@@ -1,0 +1,80 @@
+/**
+ * User Profile Types
+ *
+ * ユーザープロフィール関連の型定義です。
+ * バックエンドのAPIスキーマと一致する形で定義されています。
+ *
+ * @since v1.0.0
+ */
+
+/**
+ * ユーザープロフィール型
+ *
+ * @description バックエンドのUserProfileスキーマに対応する型定義です。
+ * API から取得されるユーザープロフィール情報を表現します。
+ *
+ * @example
+ * ```typescript
+ * const profile: UserProfile = {
+ *   id: 1,
+ *   cognito_sub: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+ *   display_name: "田中太郎",
+ *   icon_url: "https://example.com/avatar.jpg",
+ *   created_at: "2025-01-01T00:00:00Z",
+ *   updated_at: "2025-01-01T00:00:00Z"
+ * };
+ * ```
+ */
+export interface UserProfile {
+  /** ユーザープロフィールID */
+  id: number;
+  /** CognitoユーザーID */
+  cognito_sub: string;
+  /** 表示名 */
+  display_name?: string;
+  /** アイコン画像URL */
+  icon_url?: string;
+  /** 作成日時 */
+  created_at: string;
+  /** 更新日時 */
+  updated_at: string;
+}
+
+/**
+ * ユーザープロフィール入力型
+ *
+ * @description ユーザープロフィール作成・更新時に使用する入力データの型です。
+ * バックエンドのUserProfileInputスキーマに対応します。
+ *
+ * @example
+ * ```typescript
+ * const profileInput: UserProfileInput = {
+ *   display_name: "田中太郎",
+ *   icon_url: "https://example.com/avatar.jpg"
+ * };
+ * ```
+ */
+export interface UserProfileInput {
+  /** 表示名 */
+  display_name?: string;
+  /** アイコン画像URL */
+  icon_url?: string;
+}
+
+/**
+ * プロフィール作成フォーム型
+ *
+ * @description 初回ログイン時のプロフィール作成フォームで使用する型です。
+ * 今回の実装ではdisplay_nameのみを取得します。
+ *
+ * @example
+ * ```typescript
+ * const formData: ProfileCreateForm = {
+ *   display_name: "田中太郎"
+ * };
+ * ```
+ */
+export interface ProfileCreateForm {
+  /** 表示名（必須） */
+  display_name: string;
+}


### PR DESCRIPTION
## 概要

Issue #33: 初回ログイン時にユーザプロフィールを作成する機能を実装しました。

## 実装内容

### 新規ファイル
- `front/src/types/user.ts`: ユーザープロフィール関連の型定義
- `front/src/lib/api/user.ts`: ユーザープロフィールAPI呼び出し機能
- `front/src/components/user/ProfileSetupForm.tsx`: プロフィール作成フォームコンポーネント

### 修正ファイル
- `front/src/app/auth/login/page.tsx`: ログイン後のプロフィール確認・作成機能を追加

## 機能詳細

### ログインフロー
1. **従来通りのログイン**: メールアドレス・パスワードでCognito認証
2. **プロフィール存在確認**: `GET /users/profile` APIでプロフィールの有無をチェック
3. **分岐処理**:
   - **プロフィール存在** (200): ホームページへリダイレクト
   - **プロフィール未存在** (404): プロフィール作成フォームを表示

### プロフィール作成
- **入力項目**: display_name（表示名）のみ（アイコンは対象外）
- **バリデーション**: 必須チェック、1-50文字の制限
- **API呼び出し**: `POST /users/profile` でプロフィール作成
- **成功時**: ホームページへリダイレクト

### エラーハンドリング
- APIエラー時の適切なメッセージ表示
- プロフィール作成済み (409) の場合はホームページへリダイレクト
- その他のエラー時は再試行可能な状態に戻す

## 制約事項

- **アイコンアップロード**: Issue #34で別途対応予定のため今回は対象外
- **display_nameのみ**: 要件通りdisplay_nameのみを取得・DB格納

## テストケース

### 正常系
- [x] 初回ログイン時にプロフィール作成フォームが表示される
- [x] display_nameを入力してプロフィール作成が成功する
- [x] 2回目以降のログイン時はプロフィール作成をスキップする

### 異常系
- [x] プロフィール取得APIエラー時の適切なハンドリング
- [x] プロフィール作成APIエラー時の適切なハンドリング
- [x] 入力バリデーションエラーの表示

## 影響範囲

- **既存機能への影響**: なし（既存のログイン機能は維持）
- **新規依存関係**: なし（既存のAPIクライアントとUIコンポーネントを使用）

## レビューポイント

1. プロフィール存在確認の404ハンドリングが適切か
2. プロフィール作成フォームのUX・バリデーションが適切か
3. エラーハンドリングが十分か
4. 型安全性が確保されているか

Closes #33