### PR TITLE
feat(profile): implement user profile creation functionality

### DIFF
--- a/front/src/app/profile/create/page.tsx
+++ b/front/src/app/profile/create/page.tsx
@@ -1,0 +1,197 @@
+/**
+ * Profile Create Page
+ *
+ * ユーザープロフィール作成ページです。
+ * issue #33の要件に基づき、display_nameのみの入力によるプロフィール作成機能を提供します。
+ * プロフィール作成完了後は、元のページまたはホームページにリダイレクトします。
+ *
+ * @since v1.0.0
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { useAuthContext } from '@/components/auth/AuthProvider';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { ProfileCreateForm } from '@/components/profile/ProfileCreateForm';
+import { useProfile } from '@/hooks/useProfile';
+import { getAndClearReturnPath } from '@/hooks/useProfileGuard';
+import type { UserProfileInput } from '@/types/api';
+
+// Force client-side rendering for this page
+export const dynamic = 'force-dynamic';
+
+/**
+ * プロフィール作成ページコンポーネント
+ *
+ * @description 認証済みユーザーの初回プロフィール作成に使用されるページです。
+ * issue #33の要件に従い、以下の機能を提供します：
+ * 
+ * - 認証状態の確認（未認証の場合はログインページにリダイレクト）
+ * - プロフィール作成フォームの表示
+ * - display_nameの入力とバリデーション
+ * - POST /users/profile APIへの送信
+ * - 作成完了後の適切なページへのリダイレクト
+ * - エラーハンドリングとユーザーフィードバック
+ *
+ * @returns プロフィール作成ページ
+ */
+export default function ProfileCreatePage() {
+  const router = useRouter();
+  const { authState } = useAuthContext();
+  const { profileState, createUserProfile } = useProfile();
+  
+  const [isInitializing, setIsInitializing] = useState(true);
+
+  /**
+   * 認証状態チェックとプロフィール存在確認
+   */
+  useEffect(() => {
+    const initializePage = async () => {
+      // 認証状態が確定するまで待機
+      if (authState.isAuthenticated === undefined) {
+        return;
+      }
+
+      // 未認証の場合はログインページにリダイレクト
+      if (!authState.isAuthenticated) {
+        router.push('/auth/login');
+        return;
+      }
+
+      // プロフィールが既に存在する場合はホームまたは元のページにリダイレクト
+      if (profileState.initialized && profileState.exists) {
+        const returnPath = getAndClearReturnPath();
+        router.push(returnPath || '/');
+        return;
+      }
+
+      setIsInitializing(false);
+    };
+
+    initializePage();
+  }, [
+    authState.isAuthenticated,
+    profileState.initialized,
+    profileState.exists,
+    router,
+  ]);
+
+  /**
+   * プロフィール作成処理
+   */
+  const handleProfileCreate = async (profileData: UserProfileInput) => {
+    try {
+      await createUserProfile(profileData);
+      
+      // 作成成功後のリダイレクト処理
+      const returnPath = getAndClearReturnPath();
+      router.push(returnPath || '/');
+    } catch (error) {
+      // エラーはuseProfileとProfileCreateFormで処理される
+      console.error('Profile creation failed:', error);
+    }
+  };
+
+  /**
+   * キャンセル処理（通常は使用されないが、将来的な拡張のため）
+   */
+  const handleCancel = () => {
+    // ログアウト処理やホームへのリダイレクトなど
+    router.push('/');
+  };
+
+  // 初期化中のローディング表示
+  if (isInitializing || authState.isAuthenticated === undefined) {
+    return (
+      <AppLayout>
+        <div className='flex justify-center items-center min-h-[60vh]'>
+          <div className='text-center'>
+            <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4'></div>
+            <p className='text-muted-foreground'>ページを準備中...</p>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  // 認証エラーの場合（通常は上記のuseEffectでリダイレクトされる）
+  if (!authState.isAuthenticated) {
+    return (
+      <AppLayout>
+        <div className='flex justify-center items-center min-h-[60vh]'>
+          <div className='text-center'>
+            <p className='text-red-600 mb-4'>認証が必要です</p>
+            <button
+              onClick={() => router.push('/auth/login')}
+              className='text-blue-600 hover:underline'
+            >
+              ログインページに移動
+            </button>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <div className='container mx-auto px-4 py-8'>
+        {/* ページヘッダー */}
+        <div className='text-center mb-8'>
+          <h1 className='text-3xl font-bold mb-2'>My Beer Logへようこそ</h1>
+          <p className='text-muted-foreground max-w-2xl mx-auto'>
+            クラフトビールの素晴らしい世界を記録しましょう。
+            まずはあなたのプロフィールを作成して、ビールの旅を始めませんか？
+          </p>
+        </div>
+
+        {/* プロフィール作成フォーム */}
+        <div className='max-w-lg mx-auto'>
+          <ProfileCreateForm
+            onSubmit={handleProfileCreate}
+            isSubmitting={profileState.isLoading}
+            error={profileState.error}
+            showCancel={false} // 初回作成時はキャンセル不可
+            onCancel={handleCancel}
+          />
+        </div>
+
+        {/* 補足説明 */}
+        <div className='mt-12 max-w-2xl mx-auto'>
+          <div className='bg-blue-50 border border-blue-200 rounded-lg p-6'>
+            <h3 className='font-semibold text-blue-900 mb-3'>
+              My Beer Logでできること
+            </h3>
+            <ul className='space-y-2 text-sm text-blue-700'>
+              <li className='flex items-start'>
+                <span className='mr-2'>🍺</span>
+                <span>GPS位置情報を使った醸造所でのチェックイン</span>
+              </li>
+              <li className='flex items-start'>
+                <span className='mr-2'>📍</span>
+                <span>近くの醸造所の検索と情報閲覧</span>
+              </li>
+              <li className='flex items-start'>
+                <span className='mr-2'>📊</span>
+                <span>あなたのビール体験の記録と統計</span>
+              </li>
+              <li className='flex items-start'>
+                <span className='mr-2'>🏆</span>
+                <span>訪問実績に基づくバッジの獲得（今後追加予定）</span>
+              </li>
+            </ul>
+          </div>
+          
+          <div className='mt-6 text-center'>
+            <p className='text-xs text-muted-foreground'>
+              プロフィール作成後も、設定ページでいつでも表示名を変更できます。
+            </p>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/front/src/components/profile/ProfileCreateForm.tsx
+++ b/front/src/components/profile/ProfileCreateForm.tsx
@@ -1,0 +1,251 @@
+/**
+ * Profile Create Form Component
+ *
+ * ユーザープロフィール作成用のフォームコンポーネントです。
+ * display_nameの入力とバリデーション、API連携を提供します。
+ * issue #33の要件に基づき、アイコンアップロード機能は含まれていません。
+ *
+ * @since v1.0.0
+ */
+
+'use client';
+
+import { User, Loader2 } from 'lucide-react';
+import React, { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { UserProfileInput } from '@/types/api';
+
+/**
+ * プロフィール作成フォームのプロパティ
+ */
+export interface ProfileCreateFormProps {
+  /** フォーム送信時のコールバック関数 */
+  onSubmit: (profileData: UserProfileInput) => Promise<void>;
+  /** フォーム送信中フラグ */
+  isSubmitting?: boolean;
+  /** エラーメッセージ */
+  error?: string | null;
+  /** キャンセルボタンの表示フラグ */
+  showCancel?: boolean;
+  /** キャンセル時のコールバック関数 */
+  onCancel?: () => void;
+}
+
+/**
+ * プロフィール作成フォームコンポーネント
+ *
+ * @description 新規ユーザーのプロフィール作成に使用するフォームです。
+ * display_nameの入力とバリデーションを提供し、issue #33の要件に従って
+ * アイコンアップロード機能は含まれていません。
+ *
+ * @param props - フォームのプロパティ
+ * @returns プロフィール作成フォーム
+ *
+ * @example
+ * ```tsx
+ * const ProfileCreatePage = () => {
+ *   const { createUserProfile, profileState } = useProfile();
+ *   
+ *   const handleSubmit = async (data: UserProfileInput) => {
+ *     try {
+ *       await createUserProfile(data);
+ *       router.push('/');
+ *     } catch (error) {
+ *       console.error('プロフィール作成失敗:', error);
+ *     }
+ *   };
+ *
+ *   return (
+ *     <ProfileCreateForm
+ *       onSubmit={handleSubmit}
+ *       isSubmitting={profileState.isLoading}
+ *       error={profileState.error}
+ *     />
+ *   );
+ * };
+ * ```
+ */
+export function ProfileCreateForm({
+  onSubmit,
+  isSubmitting = false,
+  error = null,
+  showCancel = false,
+  onCancel,
+}: ProfileCreateFormProps) {
+  const [displayName, setDisplayName] = useState('');
+  const [validationError, setValidationError] = useState('');
+
+  /**
+   * バリデーション実行
+   */
+  const validateForm = (): boolean => {
+    if (!displayName.trim()) {
+      setValidationError('表示名を入力してください');
+      return false;
+    }
+
+    if (displayName.trim().length < 1) {
+      setValidationError('表示名は1文字以上入力してください');
+      return false;
+    }
+
+    if (displayName.trim().length > 50) {
+      setValidationError('表示名は50文字以内で入力してください');
+      return false;
+    }
+
+    // 基本的な文字チェック（絵文字やHTMLタグを含む場合の警告）
+    const hasUnsafeChars = /<[^>]*>/.test(displayName);
+    if (hasUnsafeChars) {
+      setValidationError('表示名にHTMLタグを含めることはできません');
+      return false;
+    }
+
+    setValidationError('');
+    return true;
+  };
+
+  /**
+   * フォーム送信処理
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (isSubmitting) {
+      return;
+    }
+
+    if (!validateForm()) {
+      return;
+    }
+
+    try {
+      await onSubmit({
+        displayName: displayName.trim(),
+      });
+    } catch (error) {
+      // エラーハンドリングは親コンポーネントで行う
+      console.error('Profile creation failed:', error);
+    }
+  };
+
+  /**
+   * 入力値変更時の処理
+   */
+  const handleDisplayNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDisplayName(e.target.value);
+    // リアルタイムバリデーション用にエラーをクリア
+    if (validationError) {
+      setValidationError('');
+    }
+  };
+
+  return (
+    <div className='max-w-md mx-auto'>
+      <Card>
+        <CardHeader className='text-center'>
+          <div className='mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4'>
+            <User className='w-8 h-8 text-primary' />
+          </div>
+          <CardTitle className='text-2xl'>プロフィール作成</CardTitle>
+          <CardDescription>
+            My Beer Logへようこそ！
+            <br />
+            まずはあなたの表示名を設定しましょう
+          </CardDescription>
+        </CardHeader>
+        
+        <CardContent>
+          <form onSubmit={handleSubmit} className='space-y-4'>
+            {/* 表示名入力 */}
+            <div className='space-y-2'>
+              <Label htmlFor='displayName' className='text-sm font-medium'>
+                表示名 <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='displayName'
+                type='text'
+                value={displayName}
+                onChange={handleDisplayNameChange}
+                placeholder='例: ビール太郎'
+                maxLength={50}
+                disabled={isSubmitting}
+                className='w-full'
+                aria-describedby={
+                  validationError || error ? 'form-error' : 'form-hint'
+                }
+              />
+              <p id='form-hint' className='text-xs text-muted-foreground'>
+                他のユーザーに表示される名前です（1-50文字）
+              </p>
+            </div>
+
+            {/* エラー表示 */}
+            {(validationError || error) && (
+              <div
+                id='form-error'
+                className='p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md'
+                role='alert'
+                aria-live='polite'
+              >
+                {validationError || error}
+              </div>
+            )}
+
+            {/* フォームアクション */}
+            <div className='flex gap-3 pt-4'>
+              <Button
+                type='submit'
+                disabled={isSubmitting || !displayName.trim()}
+                className='flex-1'
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className='w-4 h-4 mr-2 animate-spin' />
+                    作成中...
+                  </>
+                ) : (
+                  'プロフィールを作成'
+                )}
+              </Button>
+              
+              {showCancel && (
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={onCancel}
+                  disabled={isSubmitting}
+                  className='px-6'
+                >
+                  キャンセル
+                </Button>
+              )}
+            </div>
+          </form>
+
+          {/* 補足情報 */}
+          <div className='mt-6 pt-6 border-t'>
+            <div className='text-xs text-muted-foreground space-y-2'>
+              <p>
+                <strong>注意:</strong> プロフィール作成後も設定画面で表示名を変更できます。
+              </p>
+              <p>
+                アイコン画像の設定は今後のアップデートで追加予定です。
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/front/src/components/profile/ProfileGuard.tsx
+++ b/front/src/components/profile/ProfileGuard.tsx
@@ -1,0 +1,206 @@
+/**
+ * Profile Guard Component
+ *
+ * プロフィール存在確認とページアクセス制御を行うガードコンポーネントです。
+ * issue #33の要件「ログイン済みの状態で画面へ訪問した際にユーザプロフィールの有無を確認し、
+ * ない場合プロフィール作成画面へ遷移」を実装します。
+ *
+ * @since v1.0.0
+ */
+
+'use client';
+
+import React, { ReactNode } from 'react';
+
+import { useAuthContext } from '@/components/auth/AuthProvider';
+import { Loading } from '@/components/ui/loading';
+import { useProfileGuard, ProfileGuardOptions } from '@/hooks/useProfileGuard';
+
+/**
+ * ProfileGuardコンポーネントのプロパティ
+ */
+export interface ProfileGuardProps extends ProfileGuardOptions {
+  /** 保護対象の子コンポーネント */
+  children: ReactNode;
+  /** カスタムローディングコンポーネント */
+  loadingComponent?: ReactNode;
+  /** ガード機能を無効にするかのフラグ */
+  disabled?: boolean;
+}
+
+/**
+ * プロフィールガードコンポーネント
+ *
+ * @description 認証済みユーザーに対してプロフィール存在確認を自動実行し、
+ * 以下の制御を行います：
+ * 
+ * 1. **未認証ユーザー**: ログインページにリダイレクト
+ * 2. **認証済み + プロフィール未作成**: プロフィール作成ページにリダイレクト  
+ * 3. **認証済み + プロフィール存在**: 子コンポーネントを表示
+ * 
+ * issue #33の要件に基づき、状態変化に応じてページ遷移を行います。
+ *
+ * @param props - ガードコンポーネントのプロパティ
+ * @returns ガード制御された子コンポーネントまたはローディング状態
+ *
+ * @example
+ * ```tsx
+ * // 基本的な使用方法
+ * const ProtectedPage = () => {
+ *   return (
+ *     <ProfileGuard>
+ *       <div>プロフィール必須のコンテンツ</div>
+ *     </ProfileGuard>
+ *   );
+ * };
+ * 
+ * // カスタマイズした使用方法
+ * const CustomProtectedPage = () => {
+ *   return (
+ *     <ProfileGuard
+ *       saveReturnPath={true}
+ *       createProfilePath="/profile/setup"
+ *       loadingComponent={<CustomLoader />}
+ *     >
+ *       <div>カスタム設定のコンテンツ</div>
+ *     </ProfileGuard>
+ *   );
+ * };
+ * ```
+ */
+export function ProfileGuard({
+  children,
+  loadingComponent,
+  disabled = false,
+  ...guardOptions
+}: ProfileGuardProps) {
+  const { authState } = useAuthContext();
+  const {
+    guardState,
+    profileExists,
+    profileLoading,
+    profileError,
+  } = useProfileGuard({
+    disabled,
+    ...guardOptions,
+  });
+
+  // ガード機能が無効の場合は子コンポーネントをそのまま表示
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  // 認証状態が確定していない場合はローディング表示
+  if (authState.isAuthenticated === undefined) {
+    return loadingComponent || <DefaultLoadingComponent message='認証状態を確認中...' />;
+  }
+
+  // プロフィール確認中の場合はローディング表示
+  if (guardState.isGuarding || profileLoading) {
+    return loadingComponent || <DefaultLoadingComponent message='プロフィールを確認中...' />;
+  }
+
+  // リダイレクト実行済みの場合はローディング表示
+  if (guardState.hasRedirected) {
+    return loadingComponent || <DefaultLoadingComponent message='ページを切り替え中...' />;
+  }
+
+  // プロフィールエラーがある場合はエラー表示
+  if (profileError && !guardState.isChecked) {
+    return (
+      <div className='flex justify-center items-center min-h-[50vh]'>
+        <div className='text-center'>
+          <p className='text-red-600 mb-2'>プロフィール確認でエラーが発生しました</p>
+          <p className='text-sm text-muted-foreground mb-4'>{profileError}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className='px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors'
+          >
+            再読み込み
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // プロフィール確認が完了していない場合はローディング表示
+  if (!guardState.isChecked) {
+    return loadingComponent || <DefaultLoadingComponent message='アクセス権限を確認中...' />;
+  }
+
+  // 認証済み + プロフィール存在する場合のみ子コンポーネントを表示
+  if (authState.isAuthenticated && profileExists) {
+    return <>{children}</>;
+  }
+
+  // その他のケース（基本的に到達しないはず）
+  return loadingComponent || <DefaultLoadingComponent message='ページを準備中...' />;
+}
+
+/**
+ * デフォルトローディングコンポーネント
+ */
+interface DefaultLoadingComponentProps {
+  message?: string;
+}
+
+function DefaultLoadingComponent({ 
+  message = 'ページを読み込み中...' 
+}: DefaultLoadingComponentProps) {
+  return (
+    <div className='flex justify-center items-center min-h-[50vh]'>
+      <div className='text-center'>
+        <Loading size='lg' className='mx-auto mb-4' />
+        <p className='text-muted-foreground'>{message}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ページ全体をプロフィールガードで保護するHOC
+ *
+ * @description ページコンポーネント全体をプロフィールガードでラップする
+ * 高次コンポーネント（HOC）です。Next.jsのページコンポーネントで使用することを想定しています。
+ *
+ * @param WrappedComponent - 保護対象のページコンポーネント
+ * @param guardOptions - ガード設定オプション
+ * @returns プロフィールガードで保護されたページコンポーネント
+ *
+ * @example
+ * ```tsx
+ * // ページコンポーネントをガードで保護
+ * const MyProtectedPage = () => {
+ *   return (
+ *     <div>
+ *       <h1>プロフィール必須のページ</h1>
+ *       <p>このコンテンツはプロフィール作成後にのみ表示されます</p>
+ *     </div>
+ *   );
+ * };
+ * 
+ * // HOCを使用してガード付きページとしてエクスポート
+ * export default withProfileGuard(MyProtectedPage, {
+ *   saveReturnPath: true
+ * });
+ * ```
+ */
+export function withProfileGuard<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  guardOptions: ProfileGuardOptions = {}
+) {
+  const GuardedComponent = (props: P) => {
+    return (
+      <ProfileGuard {...guardOptions}>
+        <WrappedComponent {...props} />
+      </ProfileGuard>
+    );
+  };
+
+  // 開発時のデバッグ用にコンポーネント名を設定
+  GuardedComponent.displayName = `withProfileGuard(${
+    WrappedComponent.displayName || WrappedComponent.name || 'Component'
+  })`;
+
+  return GuardedComponent;
+}

--- a/front/src/hooks/useProfile.ts
+++ b/front/src/hooks/useProfile.ts
@@ -1,0 +1,298 @@
+/**
+ * Profile Management Hook
+ *
+ * ユーザープロフィールの状態管理とCRUD操作を提供するカスタムフックです。
+ * 認証状態と連携し、プロフィールデータの取得・作成・更新を管理します。
+ *
+ * @since v1.0.0
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuthContext } from '@/components/auth/AuthProvider';
+import {
+  getProfile,
+  createProfile,
+  updateProfile,
+  checkProfileExists,
+} from '@/lib/api/profile';
+import type { UserProfile, UserProfileInput } from '@/types/api';
+
+/**
+ * プロフィール状態の型定義
+ */
+export interface ProfileState {
+  /** プロフィールデータ */
+  profile: UserProfile | null;
+  /** 読み込み中フラグ */
+  isLoading: boolean;
+  /** エラーメッセージ */
+  error: string | null;
+  /** プロフィールが存在するかのフラグ */
+  exists: boolean;
+  /** 初期化完了フラグ */
+  initialized: boolean;
+}
+
+/**
+ * プロフィール管理カスタムフック
+ *
+ * @description ユーザープロフィールの包括的な管理機能を提供します。
+ * 認証状態と連携し、プロフィールの存在確認、取得、作成、更新を自動化します。
+ *
+ * @returns プロフィール状態と操作関数
+ *
+ * @example
+ * ```tsx
+ * const ProfileComponent = () => {
+ *   const {
+ *     profileState,
+ *     fetchProfile,
+ *     createUserProfile,
+ *     updateUserProfile
+ *   } = useProfile();
+ *
+ *   useEffect(() => {
+ *     fetchProfile();
+ *   }, [fetchProfile]);
+ *
+ *   if (profileState.isLoading) {
+ *     return <div>読み込み中...</div>;
+ *   }
+ *
+ *   if (!profileState.exists) {
+ *     return <ProfileCreateForm onSubmit={createUserProfile} />;
+ *   }
+ *
+ *   return <div>こんにちは、{profileState.profile?.displayName}さん</div>;
+ * };
+ * ```
+ */
+export function useProfile() {
+  const { authState } = useAuthContext();
+  
+  const [profileState, setProfileState] = useState<ProfileState>({
+    profile: null,
+    isLoading: false,
+    error: null,
+    exists: false,
+    initialized: false,
+  });
+
+  /**
+   * プロフィール状態をリセット
+   */
+  const resetProfileState = useCallback(() => {
+    setProfileState({
+      profile: null,
+      isLoading: false,
+      error: null,
+      exists: false,
+      initialized: false,
+    });
+  }, []);
+
+  /**
+   * エラー状態をクリア
+   */
+  const clearError = useCallback(() => {
+    setProfileState(prev => ({
+      ...prev,
+      error: null,
+    }));
+  }, []);
+
+  /**
+   * プロフィール存在チェック
+   *
+   * @description 認証済みユーザーのプロフィールの存在を確認します。
+   * ガード機能で使用することを想定しています。
+   *
+   * @returns プロフィール存在の真偽値
+   */
+  const checkProfile = useCallback(async (): Promise<boolean> => {
+    if (!authState.isAuthenticated) {
+      return false;
+    }
+
+    try {
+      setProfileState(prev => ({ ...prev, isLoading: true, error: null }));
+      
+      const exists = await checkProfileExists();
+      
+      setProfileState(prev => ({
+        ...prev,
+        exists,
+        initialized: true,
+        isLoading: false,
+      }));
+      
+      return exists;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'プロフィール確認に失敗しました';
+      setProfileState(prev => ({
+        ...prev,
+        error: message,
+        isLoading: false,
+        initialized: true,
+      }));
+      return false;
+    }
+  }, [authState.isAuthenticated]);
+
+  /**
+   * プロフィール取得
+   *
+   * @description 認証済みユーザーのプロフィール情報を取得します。
+   * プロフィールが存在しない場合はexistsフラグがfalseになります。
+   */
+  const fetchProfile = useCallback(async (): Promise<void> => {
+    if (!authState.isAuthenticated) {
+      resetProfileState();
+      return;
+    }
+
+    try {
+      setProfileState(prev => ({ ...prev, isLoading: true, error: null }));
+      
+      const profile = await getProfile();
+      
+      setProfileState(prev => ({
+        ...prev,
+        profile,
+        exists: true,
+        initialized: true,
+        isLoading: false,
+      }));
+    } catch (error) {
+      const apiError = error as { status?: number; message?: string };
+      
+      if (apiError.status === 404) {
+        // プロフィール未作成
+        setProfileState(prev => ({
+          ...prev,
+          profile: null,
+          exists: false,
+          initialized: true,
+          isLoading: false,
+        }));
+      } else {
+        // その他のエラー
+        const message = apiError.message || 'プロフィール取得に失敗しました';
+        setProfileState(prev => ({
+          ...prev,
+          error: message,
+          initialized: true,
+          isLoading: false,
+        }));
+      }
+    }
+  }, [authState.isAuthenticated, resetProfileState]);
+
+  /**
+   * プロフィール作成
+   *
+   * @description 新規ユーザーのプロフィールを作成します。
+   * 作成成功後は自動的にプロフィール情報を更新します。
+   *
+   * @param profileData - プロフィール作成データ
+   * @throws プロフィール作成失敗時にエラーをスロー
+   */
+  const createUserProfile = useCallback(
+    async (profileData: UserProfileInput): Promise<void> => {
+      if (!authState.isAuthenticated) {
+        throw new Error('認証が必要です');
+      }
+
+      try {
+        setProfileState(prev => ({ ...prev, isLoading: true, error: null }));
+        
+        const profile = await createProfile(profileData);
+        
+        setProfileState(prev => ({
+          ...prev,
+          profile,
+          exists: true,
+          isLoading: false,
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'プロフィール作成に失敗しました';
+        setProfileState(prev => ({
+          ...prev,
+          error: message,
+          isLoading: false,
+        }));
+        throw error;
+      }
+    },
+    [authState.isAuthenticated]
+  );
+
+  /**
+   * プロフィール更新
+   *
+   * @description 認証済みユーザーのプロフィール情報を更新します。
+   * 更新成功後は自動的にプロフィール情報を更新します。
+   *
+   * @param profileData - 更新するプロフィールデータ
+   * @throws プロフィール更新失敗時にエラーをスロー
+   */
+  const updateUserProfile = useCallback(
+    async (profileData: UserProfileInput): Promise<void> => {
+      if (!authState.isAuthenticated) {
+        throw new Error('認証が必要です');
+      }
+
+      if (!profileState.exists) {
+        throw new Error('プロフィールが存在しません');
+      }
+
+      try {
+        setProfileState(prev => ({ ...prev, isLoading: true, error: null }));
+        
+        const profile = await updateProfile(profileData);
+        
+        setProfileState(prev => ({
+          ...prev,
+          profile,
+          isLoading: false,
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'プロフィール更新に失敗しました';
+        setProfileState(prev => ({
+          ...prev,
+          error: message,
+          isLoading: false,
+        }));
+        throw error;
+      }
+    },
+    [authState.isAuthenticated, profileState.exists]
+  );
+
+  /**
+   * 認証状態変化時の処理
+   */
+  useEffect(() => {
+    if (authState.isAuthenticated) {
+      fetchProfile();
+    } else {
+      resetProfileState();
+    }
+  }, [authState.isAuthenticated, fetchProfile, resetProfileState]);
+
+  return {
+    // State
+    profileState,
+
+    // Actions
+    fetchProfile,
+    createUserProfile,
+    updateUserProfile,
+    checkProfile,
+    clearError,
+    resetProfileState,
+  };
+}

--- a/front/src/hooks/useProfileGuard.ts
+++ b/front/src/hooks/useProfileGuard.ts
@@ -1,0 +1,308 @@
+/**
+ * Profile Guard Hook
+ *
+ * プロフィール存在確認とリダイレクト制御を提供するカスタムフックです。
+ * 認証済みユーザーに対してプロフィールの存在を確認し、
+ * 未作成の場合は自動的にプロフィール作成画面へリダイレクトします。
+ *
+ * @since v1.0.0
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuthContext } from '@/components/auth/AuthProvider';
+import { useProfile } from './useProfile';
+
+/**
+ * プロフィールガード状態の型定義
+ */
+export interface ProfileGuardState {
+  /** ガード処理中フラグ */
+  isGuarding: boolean;
+  /** プロフィール存在チェック完了フラグ */
+  isChecked: boolean;
+  /** リダイレクト実行済みフラグ */
+  hasRedirected: boolean;
+  /** エラーメッセージ */
+  error: string | null;
+}
+
+/**
+ * プロフィールガード設定
+ */
+export interface ProfileGuardOptions {
+  /** プロフィール作成ページのパス（デフォルト: '/profile/create'） */
+  createProfilePath?: string;
+  /** 認証ページのパス（デフォルト: '/auth/login'） */
+  loginPath?: string;
+  /** ガード機能を無効にするかのフラグ */
+  disabled?: boolean;
+  /** リダイレクト後の戻り先を保存するかのフラグ */
+  saveReturnPath?: boolean;
+}
+
+/**
+ * プロフィールガードカスタムフック
+ *
+ * @description 認証済みユーザーのプロフィール存在確認を自動実行し、
+ * 未作成の場合はプロフィール作成画面へのリダイレクトを行います。
+ * issueの要件「ログイン状態やプロフィールの有無が変わる場合、ページを遷移する必要がある」
+ * に対応した制御を提供します。
+ *
+ * @param options - ガード設定オプション
+ * @returns ガード状態とガード実行関数
+ *
+ * @example
+ * ```tsx
+ * const ProtectedPage = () => {
+ *   const { guardState, executeGuard } = useProfileGuard({
+ *     saveReturnPath: true
+ *   });
+ *
+ *   useEffect(() => {
+ *     executeGuard();
+ *   }, [executeGuard]);
+ *
+ *   if (guardState.isGuarding) {
+ *     return <div>プロフィール確認中...</div>;
+ *   }
+ *
+ *   if (!guardState.isChecked) {
+ *     return <div>読み込み中...</div>;
+ *   }
+ *
+ *   return <div>メインコンテンツ</div>;
+ * };
+ * ```
+ */
+export function useProfileGuard(options: ProfileGuardOptions = {}) {
+  const router = useRouter();
+  const { authState } = useAuthContext();
+  const { profileState, checkProfile } = useProfile();
+  
+  const {
+    createProfilePath = '/profile/create',
+    loginPath = '/auth/login',
+    disabled = false,
+    saveReturnPath = false,
+  } = options;
+
+  const [guardState, setGuardState] = useState<ProfileGuardState>({
+    isGuarding: false,
+    isChecked: false,
+    hasRedirected: false,
+    error: null,
+  });
+
+  /**
+   * 戻り先パスを保存
+   */
+  const saveCurrentPath = useCallback(() => {
+    if (saveReturnPath && typeof window !== 'undefined') {
+      const currentPath = window.location.pathname + window.location.search;
+      sessionStorage.setItem('profileGuardReturnPath', currentPath);
+    }
+  }, [saveReturnPath]);
+
+  /**
+   * エラー状態をクリア
+   */
+  const clearError = useCallback(() => {
+    setGuardState(prev => ({
+      ...prev,
+      error: null,
+    }));
+  }, []);
+
+  /**
+   * ガード状態をリセット
+   */
+  const resetGuardState = useCallback(() => {
+    setGuardState({
+      isGuarding: false,
+      isChecked: false,
+      hasRedirected: false,
+      error: null,
+    });
+  }, []);
+
+  /**
+   * プロフィールガード実行
+   *
+   * @description プロフィールの存在確認を実行し、必要に応じてリダイレクトを行います。
+   * 以下のケースでリダイレクトが発生します：
+   * - 未認証の場合 → ログインページ
+   * - 認証済みでプロフィール未作成の場合 → プロフィール作成ページ
+   */
+  const executeGuard = useCallback(async (): Promise<void> => {
+    if (disabled || guardState.hasRedirected) {
+      return;
+    }
+
+    try {
+      setGuardState(prev => ({
+        ...prev,
+        isGuarding: true,
+        error: null,
+      }));
+
+      // 未認証の場合はログインページにリダイレクト
+      if (!authState.isAuthenticated) {
+        if (saveReturnPath) {
+          saveCurrentPath();
+        }
+        setGuardState(prev => ({
+          ...prev,
+          hasRedirected: true,
+          isGuarding: false,
+        }));
+        router.push(loginPath);
+        return;
+      }
+
+      // プロフィール存在確認
+      const profileExists = await checkProfile();
+      
+      if (!profileExists) {
+        // プロフィール未作成の場合はプロフィール作成画面にリダイレクト
+        if (saveReturnPath) {
+          saveCurrentPath();
+        }
+        setGuardState(prev => ({
+          ...prev,
+          hasRedirected: true,
+          isGuarding: false,
+        }));
+        router.push(createProfilePath);
+        return;
+      }
+
+      // プロフィール存在する場合はガード処理完了
+      setGuardState(prev => ({
+        ...prev,
+        isChecked: true,
+        isGuarding: false,
+      }));
+
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'プロフィール確認中にエラーが発生しました';
+      setGuardState(prev => ({
+        ...prev,
+        error: message,
+        isGuarding: false,
+      }));
+    }
+  }, [
+    disabled,
+    guardState.hasRedirected,
+    authState.isAuthenticated,
+    checkProfile,
+    saveReturnPath,
+    saveCurrentPath,
+    router,
+    loginPath,
+    createProfilePath,
+  ]);
+
+  /**
+   * 認証状態変化時の自動ガード実行
+   */
+  useEffect(() => {
+    if (!disabled && authState.isAuthenticated !== undefined) {
+      executeGuard();
+    }
+  }, [authState.isAuthenticated, executeGuard, disabled]);
+
+  /**
+   * 認証状態が未認証になった場合のリセット
+   */
+  useEffect(() => {
+    if (!authState.isAuthenticated) {
+      resetGuardState();
+    }
+  }, [authState.isAuthenticated, resetGuardState]);
+
+  /**
+   * プロフィール状態変化の監視
+   */
+  useEffect(() => {
+    if (
+      !disabled &&
+      authState.isAuthenticated &&
+      profileState.initialized &&
+      !profileState.exists &&
+      !guardState.hasRedirected
+    ) {
+      // プロフィール未作成が確認された場合のリダイレクト
+      if (saveReturnPath) {
+        saveCurrentPath();
+      }
+      setGuardState(prev => ({
+        ...prev,
+        hasRedirected: true,
+      }));
+      router.push(createProfilePath);
+    }
+  }, [
+    disabled,
+    authState.isAuthenticated,
+    profileState.initialized,
+    profileState.exists,
+    guardState.hasRedirected,
+    saveReturnPath,
+    saveCurrentPath,
+    router,
+    createProfilePath,
+  ]);
+
+  return {
+    // State
+    guardState,
+    
+    // Profile state from useProfile for convenience
+    profileExists: profileState.exists,
+    profileLoading: profileState.isLoading,
+    profileError: profileState.error,
+
+    // Actions
+    executeGuard,
+    clearError,
+    resetGuardState,
+  };
+}
+
+/**
+ * 保存された戻り先パスを取得・削除
+ *
+ * @description プロフィール作成完了後などに、元のページに戻るために使用します。
+ * 
+ * @returns 保存されていた戻り先パス（存在しない場合はnull）
+ *
+ * @example
+ * ```typescript
+ * const ProfileCreatePage = () => {
+ *   const router = useRouter();
+ *   
+ *   const handleProfileCreated = () => {
+ *     const returnPath = getAndClearReturnPath();
+ *     router.push(returnPath || '/');
+ *   };
+ * };
+ * ```
+ */
+export function getAndClearReturnPath(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  
+  const returnPath = sessionStorage.getItem('profileGuardReturnPath');
+  if (returnPath) {
+    sessionStorage.removeItem('profileGuardReturnPath');
+    return returnPath;
+  }
+  
+  return null;
+}

--- a/front/src/lib/api/index.ts
+++ b/front/src/lib/api/index.ts
@@ -1,5 +1,8 @@
 // API client
 import { apiClient } from './client';
 
+// Profile API functions
+export * from './profile';
+
 // Export the real API client
 export default apiClient;

--- a/front/src/lib/api/profile.ts
+++ b/front/src/lib/api/profile.ts
@@ -1,0 +1,128 @@
+/**
+ * Profile API Client
+ *
+ * ユーザープロフィールのCRUD操作を提供するAPIクライアントです。
+ * バックエンドのユーザープロフィール関連エンドポイントと連携します。
+ *
+ * @since v1.0.0
+ */
+
+import { apiClient } from './client';
+import type { UserProfile, UserProfileInput } from '@/types/api';
+
+/**
+ * ユーザープロフィール取得
+ *
+ * @description 認証済みユーザーのプロフィール情報を取得します。
+ * プロフィールが存在しない場合は404エラーが返されます。
+ *
+ * @returns ユーザープロフィール情報
+ * @throws API エラー（404: プロフィール未作成、401: 未認証）
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const profile = await getProfile();
+ *   console.log('プロフィール:', profile);
+ * } catch (error) {
+ *   if (error.status === 404) {
+ *     console.log('プロフィール未作成');
+ *   }
+ * }
+ * ```
+ */
+export async function getProfile(): Promise<UserProfile> {
+  return apiClient.get<UserProfile>('/users/profile');
+}
+
+/**
+ * ユーザープロフィール作成
+ *
+ * @description 新規ユーザーのプロフィールを作成します。
+ * 認証済みのCognito Subにプロフィールをリンクします。
+ *
+ * @param profileData - プロフィール作成データ（display_name, icon_url）
+ * @returns 作成されたプロフィール情報
+ * @throws API エラー（400: バリデーションエラー、409: 既に存在、401: 未認証）
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const newProfile = await createProfile({
+ *     displayName: 'ビール太郎',
+ *     iconUrl: 'https://example.com/avatar.jpg'
+ *   });
+ *   console.log('プロフィール作成完了:', newProfile);
+ * } catch (error) {
+ *   if (error.status === 409) {
+ *     console.log('プロフィールは既に存在します');
+ *   }
+ * }
+ * ```
+ */
+export async function createProfile(
+  profileData: UserProfileInput
+): Promise<UserProfile> {
+  return apiClient.post<UserProfile>('/users/profile', profileData);
+}
+
+/**
+ * ユーザープロフィール更新
+ *
+ * @description 認証済みユーザーのプロフィール情報を更新します。
+ * 部分更新が可能で、指定されたフィールドのみが更新されます。
+ *
+ * @param profileData - 更新するプロフィールデータ
+ * @returns 更新されたプロフィール情報
+ * @throws API エラー（400: バリデーションエラー、404: プロフィール未作成、401: 未認証）
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const updatedProfile = await updateProfile({
+ *     displayName: '新しい表示名'
+ *   });
+ *   console.log('プロフィール更新完了:', updatedProfile);
+ * } catch (error) {
+ *   if (error.status === 404) {
+ *     console.log('プロフィールが見つかりません');
+ *   }
+ * }
+ * ```
+ */
+export async function updateProfile(
+  profileData: UserProfileInput
+): Promise<UserProfile> {
+  return apiClient.put<UserProfile>('/users/profile', profileData);
+}
+
+/**
+ * プロフィール存在チェック
+ *
+ * @description ユーザープロフィールの存在を確認します。
+ * ガード処理やUI状態管理で使用することを想定しています。
+ *
+ * @returns プロフィールが存在するかの真偽値
+ *
+ * @example
+ * ```typescript
+ * const profileExists = await checkProfileExists();
+ * if (!profileExists) {
+ *   // プロフィール作成画面にリダイレクト
+ *   router.push('/profile/create');
+ * }
+ * ```
+ */
+export async function checkProfileExists(): Promise<boolean> {
+  try {
+    await getProfile();
+    return true;
+  } catch (error) {
+    const apiError = error as { status?: number };
+    if (apiError.status === 404) {
+      return false;
+    }
+    // その他のエラー（401等）は再スロー
+    throw error;
+  }
+}

--- a/front/src/lib/constants.ts
+++ b/front/src/lib/constants.ts
@@ -214,6 +214,7 @@ export const ROUTES = {
   register: '/auth/register',
   confirmSignup: '/auth/confirm-signup',
   profile: '/profile',
+  profileCreate: '/profile/create',
   breweries: '/brewery',
   breweryDetail: (id: number) => `/brewery/${id}`,
   nearbyBreweries: '/brewery/nearby',
@@ -262,6 +263,8 @@ export const SUCCESS_MESSAGES = {
   logoutSuccess: 'ログアウトしました',
   /** ユーザーアカウント作成成功 */
   registerSuccess: 'アカウントを作成しました',
+  /** ユーザープロフィール作成成功 */
+  profileCreated: 'プロフィールを作成しました',
   /** ユーザープロフィール更新成功 */
   profileUpdated: 'プロフィールを更新しました',
   /** 醸造所チェックイン成功 */


### PR DESCRIPTION
## Summary

Implements issue #33 requirements for user profile creation functionality:

- ✅ **プロフィール存在確認**: ログイン済み状態での自動チェック
- ✅ **自動リダイレクト**: プロフィール未作成時に`/profile/create`へ遷移  
- ✅ **プロフィール作成**: display_nameのみの入力フォーム（アイコンは除外）
- ✅ **API連携**: `POST /users/profile`エンドポイントとの統合
- ✅ **状態管理**: ログイン状態やプロフィール有無の変化時のページ遷移制御

## 実装内容

### 新規作成ファイル
- `lib/api/profile.ts`: プロフィールAPI呼び出し関数
- `hooks/useProfile.ts`: プロフィール状態管理フック
- `hooks/useProfileGuard.ts`: プロフィールガードフック（リダイレクト制御）
- `components/profile/ProfileCreateForm.tsx`: プロフィール作成フォームコンポーネント
- `app/profile/create/page.tsx`: プロフィール作成ページ
- `components/profile/ProfileGuard.tsx`: プロフィールガードコンポーネント

### 更新ファイル
- `lib/api/index.ts`: プロフィールAPI関数のエクスポート追加
- `lib/constants.ts`: プロフィール作成ルート(`/profile/create`)とメッセージ追加

## 技術仕様

### アーキテクチャ
```
AWS Cognito認証 → プロフィール存在確認(API) → 適切な画面表示/遷移
```

### 主要フロー
1. ユーザーがページにアクセス
2. AWS Cognitoの認証状態を確認  
3. 認証済みの場合、`GET /users/profile`でプロフィール存在確認
4. プロフィール未作成（404）→ `/profile/create`に自動遷移
5. display_nameを入力して`POST /users/profile`でプロフィール作成
6. 作成成功後 → 元のページまたはホームにリダイレクト

### 制約事項
- **アイコン機能除外**: issue #34で別途実装予定（インフラ変更のため）
- **display_nameのみ**: 1-50文字、HTMLタグ禁止のバリデーション実装

## Test plan

- [ ] 未認証ユーザーのアクセス制御確認
- [ ] 既存プロフィールユーザーの正常表示確認  
- [ ] プロフィール未作成ユーザーの自動リダイレクト確認
- [ ] プロフィール作成フォームのバリデーション確認
- [ ] API連携（作成成功・エラー）の動作確認
- [ ] リダイレクト後の元ページ復帰確認
- [ ] TypeScript型チェック・ESLint・テスト通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)