### PR TITLE
アイコン画像アップロード用のS3バケット+CloudFront構成を追加

### DIFF
--- a/infra/beerlog_template.yml
+++ b/infra/beerlog_template.yml
@@ -457,7 +457,7 @@ Resources:
 
   BeerLogApiDeployment:
     Type: AWS::ApiGateway::Deployment
-    DependsOn: 
+    DependsOn:
       - BeerLogApiMethod
       - BeerLogApiAuthorizer
     Properties:
@@ -564,8 +564,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      NotificationConfiguration:
-        CloudWatchConfigurations: []
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders: ['*']
@@ -599,7 +597,8 @@ Resources:
         DefaultRootObject: ''
         Enabled: true
         HttpVersion: http2
-        PriceClass: !FindInMap [EnvironmentConfig, !Ref Environment, CloudFrontPriceClass]
+        PriceClass:
+          !FindInMap [EnvironmentConfig, !Ref Environment, CloudFrontPriceClass]
         Origins:
           - Id: !Sub ${BeerLogIconImagesBucket}-origin
             DomainName: !GetAtt BeerLogIconImagesBucket.RegionalDomainName
@@ -653,7 +652,7 @@ Resources:
             Effect: Deny
             Principal: '*'
             Action: s3:*
-            Resource: 
+            Resource:
               - !GetAtt BeerLogIconImagesBucket.Arn
               - !Sub ${BeerLogIconImagesBucket.Arn}/*
             Condition:

--- a/infra/beerlog_template.yml
+++ b/infra/beerlog_template.yml
@@ -549,6 +549,119 @@ Resources:
       UserPoolId: !Ref BeerLogCognitoUserPool
       GenerateSecret: false
 
+  # S3バケット（アイコン画像用）
+  BeerLogIconImagesBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub beerlog-${Environment}-icon-images-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: true
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      NotificationConfiguration:
+        CloudWatchConfigurations: []
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders: ['*']
+            AllowedMethods: [GET, PUT, POST, DELETE]
+            AllowedOrigins: ['*']
+            ExposedHeaders: ['ETag']
+            MaxAge: 3000
+      Tags:
+        - Key: Name
+          Value: !Sub BeerLog-${Environment}-IconImagesBucket
+        - Key: Environment
+          Value: !Ref Environment
+
+  # Origin Access Control（OAC）- 新しい推奨方式
+  BeerLogIconImagesOAC:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub BeerLog-${Environment}-IconImages-OAC
+        Description: !Sub 'Origin Access Control for BeerLog icon images (${Environment})'
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # CloudFrontディストリビューション（アイコン画像用）
+  BeerLogIconImagesCloudFront:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: !Sub 'BeerLog Icon Images CloudFront Distribution (${Environment})'
+        DefaultRootObject: ''
+        Enabled: true
+        HttpVersion: http2
+        PriceClass: !FindInMap [EnvironmentConfig, !Ref Environment, CloudFrontPriceClass]
+        Origins:
+          - Id: !Sub ${BeerLogIconImagesBucket}-origin
+            DomainName: !GetAtt BeerLogIconImagesBucket.RegionalDomainName
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+            OriginAccessControlId: !GetAtt BeerLogIconImagesOAC.Id
+        DefaultCacheBehavior:
+          TargetOriginId: !Sub ${BeerLogIconImagesBucket}-origin
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          CachedMethods: [GET, HEAD]
+          Compress: true
+          ForwardedValues:
+            QueryString: false
+            Cookies:
+              Forward: none
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # AWS Managed CachingOptimized
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: '/404.html'
+            ErrorCachingMinTTL: 300
+          - ErrorCode: 404
+            ResponseCode: 404
+            ResponsePagePath: '/404.html'
+            ErrorCachingMinTTL: 300
+      Tags:
+        - Key: Name
+          Value: !Sub BeerLog-${Environment}-IconImagesCloudFront
+        - Key: Environment
+          Value: !Ref Environment
+
+  # S3バケットポリシー（CloudFront経由のみアクセス許可）
+  BeerLogIconImagesBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref BeerLogIconImagesBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowCloudFrontServicePrincipal
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub ${BeerLogIconImagesBucket.Arn}/*
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${BeerLogIconImagesCloudFront}
+          - Sid: DenyDirectAccess
+            Effect: Deny
+            Principal: '*'
+            Action: s3:*
+            Resource: 
+              - !GetAtt BeerLogIconImagesBucket.Arn
+              - !Sub ${BeerLogIconImagesBucket.Arn}/*
+            Condition:
+              StringNotEquals:
+                AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${BeerLogIconImagesCloudFront}
+              Bool:
+                aws:SecureTransport: 'false'
+
   # Systems Manager用のVPCエンドポイント
   SSMEndpoint:
     Type: AWS::EC2::VPCEndpoint
@@ -648,3 +761,27 @@ Outputs:
     Value: !Ref BeerLogApiAuthorizer
     Export:
       Name: !Sub ${AWS::StackName}-ApiAuthorizer
+
+  IconImagesBucketName:
+    Description: アイコン画像用S3バケット名
+    Value: !Ref BeerLogIconImagesBucket
+    Export:
+      Name: !Sub ${AWS::StackName}-IconImagesBucketName
+
+  IconImagesCloudFrontDomainName:
+    Description: アイコン画像用CloudFrontドメイン名
+    Value: !GetAtt BeerLogIconImagesCloudFront.DomainName
+    Export:
+      Name: !Sub ${AWS::StackName}-IconImagesCloudFrontDomainName
+
+  IconImagesCloudFrontURL:
+    Description: アイコン画像用CloudFront URL
+    Value: !Sub 'https://${BeerLogIconImagesCloudFront.DomainName}'
+    Export:
+      Name: !Sub ${AWS::StackName}-IconImagesCloudFrontURL
+
+  IconImagesOriginAccessControlId:
+    Description: アイコン画像用Origin Access Control ID
+    Value: !GetAtt BeerLogIconImagesOAC.Id
+    Export:
+      Name: !Sub ${AWS::StackName}-IconImagesOriginAccessControlId


### PR DESCRIPTION
## 概要

Issue #40 に対応し、ユーザーアイコン画像アップロード用のS3バケットとCloudFront構成をCloudFormationテンプレートに追加しました。

## 実装内容

### 追加したAWSリソース

1. **S3バケット** (`BeerLogIconImagesBucket`)
   - アイコン画像専用バケット
   - AES256暗号化設定
   - パブリックアクセスブロック設定
   - CORS設定（画像アップロード対応）

2. **Origin Access Control (OAC)** (`BeerLogIconImagesOAC`)
   - 新しい推奨方式のOAC実装
   - S3向けSigV4署名設定
   - CloudFront経由のみアクセス許可

3. **CloudFrontディストリビューション** (`BeerLogIconImagesCloudFront`)
   - 画像配信最適化設定
   - HTTPSリダイレクト強制
   - 圧縮有効化
   - AWS Managed CachingOptimized ポリシー適用

4. **S3バケットポリシー** (`BeerLogIconImagesBucketPolicy`)
   - CloudFrontサービスプリンシパルからのアクセスのみ許可
   - 直接アクセス拒否設定
   - HTTPS通信強制

### セキュリティ特徴

- ✅ Origin Access Control (OAC) による最新のセキュリティ実装
- ✅ S3直接アクセス完全ブロック
- ✅ CloudFront経由のみアクセス許可
- ✅ HTTPS通信強制
- ✅ 環境別設定対応

### 出力値追加

- `IconImagesBucketName`: S3バケット名
- `IconImagesCloudFrontDomainName`: CloudFrontドメイン名
- `IconImagesCloudFrontURL`: CloudFront URL
- `IconImagesOriginAccessControlId`: OAC ID

## テスト方法

### CloudFormation デプロイテスト

```bash
# 開発環境でのテスト
aws cloudformation deploy \
  --template-file infra/beerlog_template.yml \
  --stack-name beerlog-dev-stack-test \
  --parameter-overrides Environment=dev \
  --capabilities CAPABILITY_NAMED_IAM
```

### セキュリティ検証

1. S3バケットへの直接アクセスが403エラーになることを確認
2. CloudFront URL経由でのアクセスが正常動作することを確認
3. OAC設定が正しく適用されていることを確認

## 関連Issue

Closes #40

## 注意事項

- フロントエンドからの署名付きURL実装は別issueで対応予定
- 現時点では配信インフラのみ構築完了
- アップロード機能は今後の実装予定

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>