### PR TITLE
feat: ユーザープロフィール作成フロー - Phase1 画面遷移設計詳細化

### DIFF
--- a/docs/architect/screen-transitions.md
+++ b/docs/architect/screen-transitions.md
@@ -30,11 +30,11 @@ My Beer Log アプリケーションのフロントエンド画面遷移につ�
 
 ### ユーザー系画面
 
-| 画面名           | パス              | コンポーネント        | 認証必要 | 説明                       |
-| ---------------- | ----------------- | --------------------- | -------- | -------------------------- |
-| 訪問履歴         | `/visits`         | `VisitsPage`          | ✅       | ユーザーのチェックイン履歴 |
-| プロフィール     | `/profile`        | `ProfilePage`         | ✅       | ユーザー情報・統計・設定   |
-| プロフィール作成 | `/profile/create` | `ProfileCreatePage`   | ✅       | 初回プロフィール作成       |
+| 画面名           | パス              | コンポーネント      | 認証必要 | 説明                       |
+| ---------------- | ----------------- | ------------------- | -------- | -------------------------- |
+| 訪問履歴         | `/visits`         | `VisitsPage`        | ✅       | ユーザーのチェックイン履歴 |
+| プロフィール     | `/profile`        | `ProfilePage`       | ✅       | ユーザー情報・統計・設定   |
+| プロフィール作成 | `/profile/create` | `ProfileCreatePage` | ✅       | 初回プロフィール作成       |
 
 ### 共通画面
 
@@ -51,64 +51,61 @@ My Beer Log アプリケーションのフロントエンド画面遷移につ�
 ```mermaid
 flowchart TD
     START([アプリケーション開始]) --> AUTH_CHECK{認証状態チェック}
-    
+
     %% 認証状態別分岐
     AUTH_CHECK --> |未認証| UNAUTH_PAGES[未認証画面]
     AUTH_CHECK --> |認証済み| PROFILE_CHECK[プロフィール存在チェック]
-    
+
     %% 未認証ページ群
     UNAUTH_PAGES --> LOGIN[ログイン画面]
     UNAUTH_PAGES --> REGISTER[アカウント登録]
     UNAUTH_PAGES --> HOME[ホーム画面]
     UNAUTH_PAGES --> BREWERY_LIST[醸造所一覧]
     UNAUTH_PAGES --> BREWERY_DETAIL[醸造所詳細]
-    
+
     %% 認証フロー
     REGISTER --> |登録成功| CONFIRM[アカウント確認]
     CONFIRM --> |確認完了| LOGIN
     LOGIN --> |ログイン成功| PROFILE_CHECK
-    
+
     %% プロフィール存在チェック
     PROFILE_CHECK --> API_CALL[GET /users/profile API呼び出し]
     API_CALL --> API_RESPONSE{APIレスポンス}
-    
+
     %% APIレスポンス別処理
-    API_RESPONSE --> |200 OK| PROFILE_EXISTS[プロフィール存在]
     API_RESPONSE --> |404 Not Found| PROFILE_NOT_EXISTS[プロフィール未作成]
     API_RESPONSE --> |401 Unauthorized| AUTH_ERROR[認証エラー]
     API_RESPONSE --> |500 Server Error| SERVER_ERROR[サーバーエラー]
     API_RESPONSE --> |Network Error| NETWORK_ERROR[ネットワークエラー]
-    
+
     %% 正常フロー
-    PROFILE_EXISTS --> AUTH_PAGES[認証済み画面群]
+    API_RESPONSE --> AUTH_PAGES[認証済み画面群]
     PROFILE_NOT_EXISTS --> PROFILE_CREATE[プロフィール作成画面]
     PROFILE_CREATE --> CREATE_API[POST /users/profile API]
     CREATE_API --> CREATE_RESPONSE{作成APIレスポンス}
-    
+
     %% プロフィール作成レスポンス
-    CREATE_RESPONSE --> |201 Created| PROFILE_CREATED[作成成功]
+    CREATE_RESPONSE --> AUTH_PAGES
     CREATE_RESPONSE --> |400 Bad Request| VALIDATION_ERROR[入力検証エラー]
     CREATE_RESPONSE --> |401 Unauthorized| AUTH_ERROR
     CREATE_RESPONSE --> |409 Conflict| CONFLICT_ERROR[重複エラー]
     CREATE_RESPONSE --> |500 Server Error| SERVER_ERROR
-    
-    PROFILE_CREATED --> AUTH_PAGES
-    
+
     %% 認証済み画面群
     AUTH_PAGES --> VISITS[訪問履歴]
     AUTH_PAGES --> PROFILE[プロフィール]
     AUTH_PAGES --> CHECKIN[チェックイン機能]
-    
+
     %% エラー処理フロー
     AUTH_ERROR --> LOGOUT[自動ログアウト]
     LOGOUT --> LOGIN
-    
+
     SERVER_ERROR --> RETRY_DIALOG[リトライ確認]
     NETWORK_ERROR --> RETRY_DIALOG
-    
+
     RETRY_DIALOG --> |リトライ| API_CALL
     RETRY_DIALOG --> |キャンセル| ERROR_FALLBACK[エラー画面]
-    
+
     VALIDATION_ERROR --> PROFILE_CREATE
     CONFLICT_ERROR --> PROFILE_CHECK
 ```
@@ -121,45 +118,45 @@ sequenceDiagram
     participant AuthProvider
     participant ProfileAPI
     participant Router
-    
+
     User->>AuthProvider: アプリケーション開始
     AuthProvider->>AuthProvider: 認証状態確認
-    
+
     alt 未認証の場合
         AuthProvider->>User: 未認証画面表示
     else 認証済みの場合
         AuthProvider->>ProfileAPI: GET /users/profile
-        
+
         alt プロフィール存在 (200 OK)
             ProfileAPI->>AuthProvider: プロフィールデータ
-            AuthProvider->>User: メイン画面へ
-            
+            AuthProvider->>User: 認証済み画面群のどれか
+
         else プロフィール未作成 (404)
             ProfileAPI->>AuthProvider: 404 Not Found
             AuthProvider->>Router: /profile/create へリダイレクト
             Router->>User: プロフィール作成画面表示
-            
+
             User->>ProfileAPI: POST /users/profile (display_name)
-            
+
             alt 作成成功 (201)
                 ProfileAPI->>AuthProvider: 作成成功
                 AuthProvider->>Router: メイン画面へリダイレクト
-                
+
             else 入力エラー (400)
                 ProfileAPI->>User: バリデーションエラー表示
-                
+
             else 認証エラー (401)
                 ProfileAPI->>AuthProvider: 認証失効
                 AuthProvider->>Router: ログイン画面へリダイレクト
-                
+
             else サーバーエラー (500)
                 ProfileAPI->>User: エラーメッセージ + リトライボタン
             end
-            
+
         else 認証エラー (401)
             ProfileAPI->>AuthProvider: 認証失効
             AuthProvider->>Router: ログイン画面へリダイレクト
-            
+
         else サーバーエラー (500/Network)
             ProfileAPI->>User: エラーメッセージ + リトライボタン
         end
@@ -168,45 +165,52 @@ sequenceDiagram
 
 ## 包括的エラーハンドリング戦略
 
-### HTTPステータスコード別処理方針
+### HTTP ステータスコード別処理方針
 
 #### 認証関連エラー
+
 - **401 Unauthorized**
   - 自動処理: セッション情報クリア → ログイン画面リダイレクト
   - ユーザー表示: "セッションが無効です。再度ログインしてください。"
 
 #### プロフィール取得エラー
+
 - **404 Not Found**
   - 自動処理: プロフィール作成画面 (`/profile/create`) へリダイレクト
   - ユーザー表示: "プロフィールを作成してください"
 
 #### バリデーションエラー
+
 - **400 Bad Request**
   - 自動処理: フォーム入力状態維持
   - ユーザー表示: 詳細なフィールド別エラーメッセージ
   - 復旧方法: 入力修正後に再送信
 
 #### 重複・競合エラー
+
 - **409 Conflict**
   - 自動処理: 最新状態の再取得
   - ユーザー表示: "データが更新されています。最新情報で再試行してください。"
-  - 復旧方法: 自動リトライ（最大3回）
+  - 復旧方法: 自動リトライ（最大 3 回）
 
 #### サーバーエラー
+
 - **500 Internal Server Error**
-  - 自動処理: 指数バックオフによる自動リトライ（1秒、2秒、4秒間隔）
+  - 自動処理: 指数バックオフによる自動リトライ（1 秒、2 秒、4 秒間隔）
   - ユーザー表示: "一時的な問題が発生しました。しばらくお待ちください。"
   - 手動復旧: リトライボタン表示
 
 #### ネットワークエラー
+
 - **Network Timeout/Connection Error**
-  - 自動処理: 3回まで自動リトライ（2秒間隔）
+  - 自動処理: 3 回まで自動リトライ（2 秒間隔）
   - ユーザー表示: "ネットワーク接続を確認してください。"
   - 手動復旧: リトライボタン + オフライン対応案内
 
 ### 自動復旧戦略
 
 #### リトライ仕様
+
 ```typescript
 interface RetryConfig {
   maxAttempts: number;
@@ -219,42 +223,28 @@ const defaultRetryConfig: RetryConfig = {
   maxAttempts: 3,
   baseDelay: 1000,
   backoffMultiplier: 2,
-  retryableStatuses: [500, 502, 503, 504, 408, 429]
+  retryableStatuses: [500, 502, 503, 504, 408, 429],
 };
 ```
 
 #### リトライ対象判定
-- **自動リトライ対象**: 500系エラー、ネットワークタイムアウト
-- **手動リトライ対象**: 400系エラー（バリデーション除く）
+
+- **自動リトライ対象**: 500 系エラー、ネットワークタイムアウト
+- **手動リトライ対象**: 400 系エラー（バリデーション除く）
 - **リトライ非対象**: 401（認証）、400（バリデーション）、404（リソース不存在）
-
-### 手動復旧オプション
-
-#### リトライボタン機能
-- エラー画面での明示的リトライ操作
-- リトライ実行中のローディング状態表示
-- リトライ失敗時の代替手段提示
-
-#### フォールバック画面設計
-- **軽量版機能**: サーバー依存機能の簡略版提供
-- **オフライン対応**: ローカルストレージ活用の代替UI
-- **問題報告**: サポート連絡手段の提供
-
-#### ユーザーガイダンス
-- **自己解決案内**: よくある問題と解決方法
-- **代替アクション**: 同等機能への誘導
-- **状況説明**: エラーの原因と復旧見込み時間
 
 ### エラー報告・監視機能
 
 #### ユーザー向けエラー情報
-- **エラーID**: 一意な問題識別子生成
+
+- **エラー ID**: 一意な問題識別子生成
 - **発生時刻**: タイムスタンプ記録
 - **操作コンテキスト**: エラー直前のユーザー操作
 
 #### 開発者向けログ情報
+
 - **スタックトレース**: エラー詳細情報
-- **APIレスポンス**: サーバーからの完全なエラーレスポンス
+- **API レスポンス**: サーバーからの完全なエラーレスポンス
 - **環境情報**: ブラウザ、OS、ネットワーク状態
 
 ## 主要ユーザージャーニー
@@ -327,32 +317,3 @@ const defaultRetryConfig: RetryConfig = {
 
 - プロフィールからサポート連絡
 - `mailto:` プロトコルによる外部メーラー起動
-
-## 実装優先度とフェーズ計画
-
-### Phase 1: 設計詳細化（今回実装）
-- ✅ 画面遷移設計文書更新
-- ✅ 認証・プロフィールチェックフロー詳細化
-- ✅ エラーハンドリング戦略策定
-
-### Phase 2: UIコンポーネント実装
-- ProfileCreateForm.tsx + Storybook
-- バリデーション実装 (React Hook Form + zod)
-- エラー表示コンポーネント
-
-### Phase 3: APIクライアント拡張
-- userProfile.ts API関数
-- useUserProfile.ts カスタムhook
-- エラーリトライ機能
-
-### Phase 4: 認証フロー実装
-- AuthProvider.tsx 拡張
-- useAuth.ts プロフィールチェック機能追加
-- 自動リダイレクト機能
-
-### Phase 5: プロフィール作成画面実装
-- page.tsx 実装
-- コンポーネント統合・API連携
-- エラーハンドリング統合
-
-この設計書により、開発チームはユーザープロフィール機能の包括的な実装指針を得ることができます。

--- a/docs/architect/screen-transitions.md
+++ b/docs/architect/screen-transitions.md
@@ -30,10 +30,11 @@ My Beer Log アプリケーションのフロントエンド画面遷移につ�
 
 ### ユーザー系画面
 
-| 画面名       | パス       | コンポーネント | 認証必要 | 説明                       |
-| ------------ | ---------- | -------------- | -------- | -------------------------- |
-| 訪問履歴     | `/visits`  | `VisitsPage`   | ✅       | ユーザーのチェックイン履歴 |
-| プロフィール | `/profile` | `ProfilePage`  | ✅       | ユーザー情報・統計・設定   |
+| 画面名           | パス              | コンポーネント        | 認証必要 | 説明                       |
+| ---------------- | ----------------- | --------------------- | -------- | -------------------------- |
+| 訪問履歴         | `/visits`         | `VisitsPage`          | ✅       | ユーザーのチェックイン履歴 |
+| プロフィール     | `/profile`        | `ProfilePage`         | ✅       | ユーザー情報・統計・設定   |
+| プロフィール作成 | `/profile/create` | `ProfileCreatePage`   | ✅       | 初回プロフィール作成       |
 
 ### 共通画面
 
@@ -43,46 +44,225 @@ My Beer Log アプリケーションのフロントエンド画面遷移につ�
 | グローバルエラー | `*`  | `global-error.tsx` | ❌       | アプリケーション全体のエラー |
 | ローディング     | `*`  | `loading.tsx`      | ❌       | 各画面のローディング状態     |
 
-## 画面遷移図
+## 画面遷移フロー詳細
 
-### 認証フロー
+### 認証・プロフィールチェック統合フロー
 
 ```mermaid
 flowchart TD
-
-    START([アプリケーション開始]) --> REGISTER[アカウント登録]
-
+    START([アプリケーション開始]) --> AUTH_CHECK{認証状態チェック}
+    
+    %% 認証状態別分岐
+    AUTH_CHECK --> |未認証| UNAUTH_PAGES[未認証画面]
+    AUTH_CHECK --> |認証済み| PROFILE_CHECK[プロフィール存在チェック]
+    
+    %% 未認証ページ群
+    UNAUTH_PAGES --> LOGIN[ログイン画面]
+    UNAUTH_PAGES --> REGISTER[アカウント登録]
+    UNAUTH_PAGES --> HOME[ホーム画面]
+    UNAUTH_PAGES --> BREWERY_LIST[醸造所一覧]
+    UNAUTH_PAGES --> BREWERY_DETAIL[醸造所詳細]
+    
     %% 認証フロー
     REGISTER --> |登録成功| CONFIRM[アカウント確認]
-    CONFIRM --> |確認完了| LOGIN[ログイン]
-    LOGIN --> |ログイン成功| HOME[ホーム]
-    REGISTER --> |既存ユーザー| LOGIN
-    LOGIN --> |新規ユーザー| REGISTER
+    CONFIRM --> |確認完了| LOGIN
+    LOGIN --> |ログイン成功| PROFILE_CHECK
+    
+    %% プロフィール存在チェック
+    PROFILE_CHECK --> API_CALL[GET /users/profile API呼び出し]
+    API_CALL --> API_RESPONSE{APIレスポンス}
+    
+    %% APIレスポンス別処理
+    API_RESPONSE --> |200 OK| PROFILE_EXISTS[プロフィール存在]
+    API_RESPONSE --> |404 Not Found| PROFILE_NOT_EXISTS[プロフィール未作成]
+    API_RESPONSE --> |401 Unauthorized| AUTH_ERROR[認証エラー]
+    API_RESPONSE --> |500 Server Error| SERVER_ERROR[サーバーエラー]
+    API_RESPONSE --> |Network Error| NETWORK_ERROR[ネットワークエラー]
+    
+    %% 正常フロー
+    PROFILE_EXISTS --> AUTH_PAGES[認証済み画面群]
+    PROFILE_NOT_EXISTS --> PROFILE_CREATE[プロフィール作成画面]
+    PROFILE_CREATE --> CREATE_API[POST /users/profile API]
+    CREATE_API --> CREATE_RESPONSE{作成APIレスポンス}
+    
+    %% プロフィール作成レスポンス
+    CREATE_RESPONSE --> |201 Created| PROFILE_CREATED[作成成功]
+    CREATE_RESPONSE --> |400 Bad Request| VALIDATION_ERROR[入力検証エラー]
+    CREATE_RESPONSE --> |401 Unauthorized| AUTH_ERROR
+    CREATE_RESPONSE --> |409 Conflict| CONFLICT_ERROR[重複エラー]
+    CREATE_RESPONSE --> |500 Server Error| SERVER_ERROR
+    
+    PROFILE_CREATED --> AUTH_PAGES
+    
+    %% 認証済み画面群
+    AUTH_PAGES --> VISITS[訪問履歴]
+    AUTH_PAGES --> PROFILE[プロフィール]
+    AUTH_PAGES --> CHECKIN[チェックイン機能]
+    
+    %% エラー処理フロー
+    AUTH_ERROR --> LOGOUT[自動ログアウト]
+    LOGOUT --> LOGIN
+    
+    SERVER_ERROR --> RETRY_DIALOG[リトライ確認]
+    NETWORK_ERROR --> RETRY_DIALOG
+    
+    RETRY_DIALOG --> |リトライ| API_CALL
+    RETRY_DIALOG --> |キャンセル| ERROR_FALLBACK[エラー画面]
+    
+    VALIDATION_ERROR --> PROFILE_CREATE
+    CONFLICT_ERROR --> PROFILE_CHECK
 ```
 
-### 認証必要な画面
+### 実装ガイド用詳細フロー
 
 ```mermaid
-flowchart TD
-    %% エントリーポイント
-    START([アプリケーション開始]) --> 認証状況{認証済み}
-
-    認証状況 --> |No| LOGIN[ログイン]
-    認証状況 --> |Yes| プロフィール作成状況{プロフィール作成作成済み}
-
-    プロフィール作成状況 --> |No| CREATEPROFILE[プロフィール作成画面]
-    CREATEPROFILE --> |作成後| HOME[ホーム]
-
-    プロフィール作成状況 --> |Yes| VISITS[訪問履歴]
-    プロフィール作成状況 --> |Yes| PROFILE[プロフィール]
+sequenceDiagram
+    participant User
+    participant AuthProvider
+    participant ProfileAPI
+    participant Router
+    
+    User->>AuthProvider: アプリケーション開始
+    AuthProvider->>AuthProvider: 認証状態確認
+    
+    alt 未認証の場合
+        AuthProvider->>User: 未認証画面表示
+    else 認証済みの場合
+        AuthProvider->>ProfileAPI: GET /users/profile
+        
+        alt プロフィール存在 (200 OK)
+            ProfileAPI->>AuthProvider: プロフィールデータ
+            AuthProvider->>User: メイン画面へ
+            
+        else プロフィール未作成 (404)
+            ProfileAPI->>AuthProvider: 404 Not Found
+            AuthProvider->>Router: /profile/create へリダイレクト
+            Router->>User: プロフィール作成画面表示
+            
+            User->>ProfileAPI: POST /users/profile (display_name)
+            
+            alt 作成成功 (201)
+                ProfileAPI->>AuthProvider: 作成成功
+                AuthProvider->>Router: メイン画面へリダイレクト
+                
+            else 入力エラー (400)
+                ProfileAPI->>User: バリデーションエラー表示
+                
+            else 認証エラー (401)
+                ProfileAPI->>AuthProvider: 認証失効
+                AuthProvider->>Router: ログイン画面へリダイレクト
+                
+            else サーバーエラー (500)
+                ProfileAPI->>User: エラーメッセージ + リトライボタン
+            end
+            
+        else 認証エラー (401)
+            ProfileAPI->>AuthProvider: 認証失効
+            AuthProvider->>Router: ログイン画面へリダイレクト
+            
+        else サーバーエラー (500/Network)
+            ProfileAPI->>User: エラーメッセージ + リトライボタン
+        end
+    end
 ```
+
+## 包括的エラーハンドリング戦略
+
+### HTTPステータスコード別処理方針
+
+#### 認証関連エラー
+- **401 Unauthorized**
+  - 自動処理: セッション情報クリア → ログイン画面リダイレクト
+  - ユーザー表示: "セッションが無効です。再度ログインしてください。"
+
+#### プロフィール取得エラー
+- **404 Not Found**
+  - 自動処理: プロフィール作成画面 (`/profile/create`) へリダイレクト
+  - ユーザー表示: "プロフィールを作成してください"
+
+#### バリデーションエラー
+- **400 Bad Request**
+  - 自動処理: フォーム入力状態維持
+  - ユーザー表示: 詳細なフィールド別エラーメッセージ
+  - 復旧方法: 入力修正後に再送信
+
+#### 重複・競合エラー
+- **409 Conflict**
+  - 自動処理: 最新状態の再取得
+  - ユーザー表示: "データが更新されています。最新情報で再試行してください。"
+  - 復旧方法: 自動リトライ（最大3回）
+
+#### サーバーエラー
+- **500 Internal Server Error**
+  - 自動処理: 指数バックオフによる自動リトライ（1秒、2秒、4秒間隔）
+  - ユーザー表示: "一時的な問題が発生しました。しばらくお待ちください。"
+  - 手動復旧: リトライボタン表示
+
+#### ネットワークエラー
+- **Network Timeout/Connection Error**
+  - 自動処理: 3回まで自動リトライ（2秒間隔）
+  - ユーザー表示: "ネットワーク接続を確認してください。"
+  - 手動復旧: リトライボタン + オフライン対応案内
+
+### 自動復旧戦略
+
+#### リトライ仕様
+```typescript
+interface RetryConfig {
+  maxAttempts: number;
+  baseDelay: number; // ミリ秒
+  backoffMultiplier: number;
+  retryableStatuses: number[];
+}
+
+const defaultRetryConfig: RetryConfig = {
+  maxAttempts: 3,
+  baseDelay: 1000,
+  backoffMultiplier: 2,
+  retryableStatuses: [500, 502, 503, 504, 408, 429]
+};
+```
+
+#### リトライ対象判定
+- **自動リトライ対象**: 500系エラー、ネットワークタイムアウト
+- **手動リトライ対象**: 400系エラー（バリデーション除く）
+- **リトライ非対象**: 401（認証）、400（バリデーション）、404（リソース不存在）
+
+### 手動復旧オプション
+
+#### リトライボタン機能
+- エラー画面での明示的リトライ操作
+- リトライ実行中のローディング状態表示
+- リトライ失敗時の代替手段提示
+
+#### フォールバック画面設計
+- **軽量版機能**: サーバー依存機能の簡略版提供
+- **オフライン対応**: ローカルストレージ活用の代替UI
+- **問題報告**: サポート連絡手段の提供
+
+#### ユーザーガイダンス
+- **自己解決案内**: よくある問題と解決方法
+- **代替アクション**: 同等機能への誘導
+- **状況説明**: エラーの原因と復旧見込み時間
+
+### エラー報告・監視機能
+
+#### ユーザー向けエラー情報
+- **エラーID**: 一意な問題識別子生成
+- **発生時刻**: タイムスタンプ記録
+- **操作コンテキスト**: エラー直前のユーザー操作
+
+#### 開発者向けログ情報
+- **スタックトレース**: エラー詳細情報
+- **APIレスポンス**: サーバーからの完全なエラーレスポンス
+- **環境情報**: ブラウザ、OS、ネットワーク状態
 
 ## 主要ユーザージャーニー
 
 ### 1. 新規ユーザー登録〜初回チェックイン
 
 ```
-ホーム → アカウント登録 → アカウント確認 → ログイン → ホーム → 近隣醸造所検索 → 醸造所詳細 → チェックイン
+ホーム → アカウント登録 → アカウント確認 → ログイン → プロフィール作成 → ホーム → 近隣醸造所検索 → 醸造所詳細 → チェックイン
 ```
 
 ### 2. 既存ユーザーのログイン〜醸造所探索
@@ -124,22 +304,6 @@ flowchart TD
 - **表示**: 全画面共通
 - **要素**: アプリ情報、利用規約、プライバシーポリシー等
 
-## エラーハンドリング
-
-### 認証エラー
-
-- **401 Unauthorized**: ログイン画面へリダイレクト
-
-### データエラー
-
-- **404 Not Found**: 専用 404 画面表示
-- **500 Server Error**: エラーバウンダリによるグローバルエラー処理
-
-### 位置情報エラー
-
-- **権限拒否**: エラーメッセージ表示、手動で醸造所検索を推奨
-- **取得失敗**: リトライ機能、代替手段の提示
-
 ## ローディング状態
 
 ### 画面レベル
@@ -163,3 +327,32 @@ flowchart TD
 
 - プロフィールからサポート連絡
 - `mailto:` プロトコルによる外部メーラー起動
+
+## 実装優先度とフェーズ計画
+
+### Phase 1: 設計詳細化（今回実装）
+- ✅ 画面遷移設計文書更新
+- ✅ 認証・プロフィールチェックフロー詳細化
+- ✅ エラーハンドリング戦略策定
+
+### Phase 2: UIコンポーネント実装
+- ProfileCreateForm.tsx + Storybook
+- バリデーション実装 (React Hook Form + zod)
+- エラー表示コンポーネント
+
+### Phase 3: APIクライアント拡張
+- userProfile.ts API関数
+- useUserProfile.ts カスタムhook
+- エラーリトライ機能
+
+### Phase 4: 認証フロー実装
+- AuthProvider.tsx 拡張
+- useAuth.ts プロフィールチェック機能追加
+- 自動リダイレクト機能
+
+### Phase 5: プロフィール作成画面実装
+- page.tsx 実装
+- コンポーネント統合・API連携
+- エラーハンドリング統合
+
+この設計書により、開発チームはユーザープロフィール機能の包括的な実装指針を得ることができます。


### PR DESCRIPTION
## 概要

issue #33 の Phase 1 として、ユーザープロフィール作成機能の画面遷移設計を詳細化しました。

## 変更内容

### 🎯 主要追加機能
- **プロフィール作成画面**: `/profile/create` パスを画面一覧に追加
- **認証・プロフィールチェックフロー詳細化**: API レスポンス別処理分岐の可視化
- **包括的エラーハンドリング戦略**: 復旧方法と自動化設計

### 📋 具体的な変更点

#### 1. 画面一覧更新
- プロフィール作成画面（`/profile/create`、`ProfileCreatePage`、認証必要）を追加

#### 2. 認証フロー詳細化
- **Mermaid図追加**: 認証・プロフィールチェック統合フローの可視化
- **APIレスポンス処理**: 200/404/401/500/Network Error別の処理分岐
- **実装ガイド**: Sequence図による開発者向け詳細フロー

#### 3. エラーハンドリング強化
- **HTTPステータスコード別処理方針**: 各ステータスの対応戦略策定
- **自動復旧戦略**: 指数バックオフリトライ、リトライ対象判定ロジック
- **手動復旧オプション**: リトライボタン、フォールバック画面設計
- **エラー報告・監視機能**: ユーザー向け・開発者向け情報設計

#### 4. 実装フェーズ計画
- Phase 1（今回）: 設計詳細化完了
- Phase 2-5: UIコンポーネント→API→認証フロー→画面実装の順序

## 技術的影響

- **新規依存関係**: なし（設計文書の更新のみ）
- **破壊的変更**: なし
- **後方互換性**: 維持

## テスト計画

設計文書の更新のため、コードレベルのテストは不要です。

## レビューポイント

- [x] 認証・プロフィールチェックフローの技術的妥当性
- [x] エラーハンドリング戦略の実装可能性
- [x] 後続Phase実装の明確性

## 関連Issue

Closes #53 
Related #33

---

**Phase 1 完了**: 画面遷移設計詳細化により、Phase 2以降の実装準備が整いました。