### PR TITLE
feat: 認証フロー拡張 - ユーザープロフィール自動チェック機能の実装

### DIFF
--- a/front/src/components/auth/AuthProvider.tsx
+++ b/front/src/components/auth/AuthProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { configureStore } from '@reduxjs/toolkit';
+import { useRouter, usePathname } from 'next/navigation';
 import React, { createContext, useContext, useEffect, ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
@@ -34,6 +35,8 @@ interface AuthProviderProps {
 
 function AuthInitializer({ children }: AuthProviderProps) {
   const auth = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     // Validate Amplify configuration
@@ -56,14 +59,77 @@ function AuthInitializer({ children }: AuthProviderProps) {
     const initializeAuth = async () => {
       try {
         await auth.refreshAuth();
+
+        // Auto-check profile after authentication is restored
+        if (auth.authState.isAuthenticated) {
+          await checkProfileAndRedirect();
+        }
       } catch (error) {
         console.log('No existing authentication found', error);
+      }
+    };
+
+    // Profile check and redirect logic
+    const checkProfileAndRedirect = async () => {
+      try {
+        // Skip profile check if already on profile creation page
+        if (pathname === '/profile/create') {
+          return;
+        }
+
+        // Check if profile exists
+        const hasProfile = await auth.checkProfile();
+
+        // Redirect to profile creation if profile doesn't exist
+        if (!hasProfile) {
+          console.log('Profile not found, redirecting to /profile/create');
+          router.push('/profile/create');
+        }
+      } catch (error) {
+        console.error('Profile check failed:', error);
+        // Don't redirect on error, let user continue
       }
     };
 
     initializeAuth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Auto-check profile when authentication state changes
+  useEffect(() => {
+    const handleAuthStateChange = async () => {
+      // Only auto-check if:
+      // 1. User is authenticated
+      // 2. Profile check is not in progress
+      // 3. Profile status is unknown (null) or false
+      // 4. Not already on profile creation page
+      if (
+        auth.authState.isAuthenticated &&
+        !auth.authState.isCheckingProfile &&
+        (auth.authState.hasProfile === null || auth.authState.hasProfile === false) &&
+        pathname !== '/profile/create'
+      ) {
+        try {
+          const hasProfile = await auth.checkProfile();
+          
+          // Redirect to profile creation if profile doesn't exist
+          if (!hasProfile) {
+            console.log('Profile not found after login, redirecting to /profile/create');
+            router.push('/profile/create');
+          }
+        } catch (error) {
+          console.error('Auto profile check failed:', error);
+          // Don't redirect on error, let user continue
+        }
+      }
+    };
+
+    // Trigger when authentication state changes to authenticated
+    if (auth.authState.isAuthenticated && !auth.authState.isLoading) {
+      handleAuthStateChange();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auth.authState.isAuthenticated, auth.authState.isLoading, pathname]);
 
   return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
 }

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -13,6 +13,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { apiClient } from '@/lib/api/client';
+import { checkUserProfile } from '@/lib/api/userProfile';
 import { cognitoAuthService } from '@/lib/auth/cognito';
 import {
   authStart,
@@ -23,6 +24,11 @@ import {
   updateTokens,
   clearError,
   setLoading,
+  profileCheckStart,
+  profileCheckSuccess,
+  profileCheckNotFound,
+  profileCheckError,
+  clearProfileError,
   selectAuth,
 } from '@/store/slices/authSlice';
 import type {
@@ -46,7 +52,7 @@ import type {
  * @example
  * ```tsx
  * const LoginForm = () => {
- *   const { authState, login, logout } = useAuth();
+ *   const { authState, login, logout, checkProfile } = useAuth();
  *
  *   const handleLogin = async () => {
  *     try {
@@ -54,14 +60,24 @@ import type {
  *         email: 'user@example.com',
  *         password: 'password123'
  *       });
+ *       
+ *       // ログイン後にプロフィール有無をチェック
+ *       const hasProfile = await checkProfile();
+ *       if (!hasProfile) {
+ *         router.push('/profile/create');
+ *       }
  *       console.log('ログイン成功');
  *     } catch (error) {
  *       console.error('ログイン失敗:', error);
  *     }
  *   };
  *
- *   if (authState.isLoading) {
- *     return <div>認証中...</div>;
+ *   if (authState.isLoading || authState.isCheckingProfile) {
+ *     return <div>処理中...</div>;
+ *   }
+ *
+ *   if (authState.isAuthenticated && authState.hasProfile === false) {
+ *     return <div>プロフィール作成が必要です</div>;
  *   }
  *
  *   if (authState.isAuthenticated) {
@@ -299,6 +315,45 @@ export function useAuth() {
   );
 
   /**
+   * プロフィール存在確認関数
+   *
+   * @description 認証済みユーザーのプロフィールが作成済みかどうかを確認します。
+   * 認証完了後の自動チェックや手動でのプロフィール状態確認に使用します。
+   *
+   * @returns プロフィール存在フラグ（true: 作成済み、false: 未作成）
+   * @throws プロフィールチェック失敗時にエラーをスロー
+   *
+   * @example
+   * ```typescript
+   * // ログイン後の自動チェック
+   * const hasProfile = await checkProfile();
+   * if (!hasProfile) {
+   *   router.push('/profile/create');
+   * }
+   * ```
+   */
+  const checkProfile = useCallback(async (): Promise<boolean> => {
+    try {
+      dispatch(profileCheckStart());
+
+      const hasProfile = await checkUserProfile();
+
+      if (hasProfile) {
+        dispatch(profileCheckSuccess());
+      } else {
+        dispatch(profileCheckNotFound());
+      }
+
+      return hasProfile;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Profile check failed';
+      dispatch(profileCheckError(message));
+      throw error;
+    }
+  }, [dispatch]);
+
+  /**
    * ユーザーログアウト関数
    *
    * @description ユーザーをログアウトし、ローカル状態をクリアします。
@@ -374,6 +429,16 @@ export function useAuth() {
     dispatch(clearError());
   }, [dispatch]);
 
+  /**
+   * プロフィールエラークリア関数
+   *
+   * @description プロフィール関連のエラー状態をクリアします。
+   * エラーメッセージを非表示にする際に使用します。
+   */
+  const clearProfileErr = useCallback(() => {
+    dispatch(clearProfileError());
+  }, [dispatch]);
+
   return {
     // State
     authState,
@@ -388,6 +453,8 @@ export function useAuth() {
     updateProfile,
     logout,
     refreshAuth,
+    checkProfile,
     clearError: clearAuthError,
+    clearProfileError: clearProfileErr,
   };
 }

--- a/front/src/lib/api/userProfile.ts
+++ b/front/src/lib/api/userProfile.ts
@@ -12,6 +12,51 @@ import type { UserProfile, UserProfileInput, ApiResponse } from '@/types/api';
 import { apiClient } from './client';
 
 /**
+ * ユーザープロフィールの存在確認
+ *
+ * @description 認証済みユーザーのプロフィールが存在するかを確認します。
+ * 404エラーを正常な状態として扱い、プロフィール有無をboolean値で返します。
+ * 認証フローでのプロフィール自動チェックに使用されます。
+ *
+ * @returns プロフィール存在フラグ（true: 存在, false: 未作成）
+ * @throws {Error} 401: 認証エラーの場合
+ * @throws {Error} 500: サーバーエラーの場合
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const hasProfile = await checkUserProfile();
+ *   if (hasProfile) {
+ *     console.log('プロフィールが存在します');
+ *   } else {
+ *     console.log('プロフィールを作成してください');
+ *     // プロフィール作成画面に遷移
+ *     router.push('/profile/create');
+ *   }
+ * } catch (error) {
+ *   console.error('プロフィールチェックに失敗:', error);
+ * }
+ * ```
+ */
+export async function checkUserProfile(): Promise<boolean> {
+  try {
+    await getUserProfile();
+    // プロフィール取得成功 = プロフィール存在
+    return true;
+  } catch (error: unknown) {
+    const apiError = error as Error & { status?: number };
+    
+    // 404エラーの場合はプロフィール未作成
+    if (apiError.status === 404) {
+      return false;
+    }
+    
+    // 404以外のエラーは再スロー
+    throw error;
+  }
+}
+
+/**
  * ユーザープロフィールを取得する
  *
  * @description 認証済みユーザーのプロフィール情報を取得します。

--- a/front/src/store/slices/authSlice.ts
+++ b/front/src/store/slices/authSlice.ts
@@ -12,6 +12,9 @@ const initialState: AuthState = {
   idToken: null,
   refreshToken: null,
   error: null,
+  hasProfile: null,
+  isCheckingProfile: false,
+  profileError: null,
 };
 
 const authSlice = createSlice({
@@ -52,6 +55,10 @@ const authSlice = createSlice({
       state.idToken = null;
       state.refreshToken = null;
       state.error = null;
+      // Profile state reset
+      state.hasProfile = null;
+      state.isCheckingProfile = false;
+      state.profileError = null;
     },
 
     // Authentication error
@@ -99,6 +106,43 @@ const authSlice = createSlice({
     setLoading: (state, action: PayloadAction<boolean>) => {
       state.isLoading = action.payload;
     },
+
+    // Profile check start
+    profileCheckStart: state => {
+      state.isCheckingProfile = true;
+      state.profileError = null;
+    },
+
+    // Profile check success (profile exists)
+    profileCheckSuccess: state => {
+      state.hasProfile = true;
+      state.isCheckingProfile = false;
+      state.profileError = null;
+    },
+
+    // Profile check not found (profile does not exist)
+    profileCheckNotFound: state => {
+      state.hasProfile = false;
+      state.isCheckingProfile = false;
+      state.profileError = null;
+    },
+
+    // Profile check error
+    profileCheckError: (state, action: PayloadAction<string>) => {
+      state.hasProfile = null;
+      state.isCheckingProfile = false;
+      state.profileError = action.payload;
+    },
+
+    // Clear profile error
+    clearProfileError: state => {
+      state.profileError = null;
+    },
+
+    // Set profile status (for manual update)
+    setProfileStatus: (state, action: PayloadAction<boolean>) => {
+      state.hasProfile = action.payload;
+    },
   },
 });
 
@@ -111,6 +155,12 @@ export const {
   updateTokens,
   clearError,
   setLoading,
+  profileCheckStart,
+  profileCheckSuccess,
+  profileCheckNotFound,
+  profileCheckError,
+  clearProfileError,
+  setProfileStatus,
 } = authSlice.actions;
 
 export default authSlice.reducer;
@@ -125,3 +175,11 @@ export const selectAccessToken = (state: { auth: AuthState }) =>
 export const selectIsLoading = (state: { auth: AuthState }) =>
   state.auth.isLoading;
 export const selectError = (state: { auth: AuthState }) => state.auth.error;
+
+// Profile selectors
+export const selectHasProfile = (state: { auth: AuthState }) =>
+  state.auth.hasProfile;
+export const selectIsCheckingProfile = (state: { auth: AuthState }) =>
+  state.auth.isCheckingProfile;
+export const selectProfileError = (state: { auth: AuthState }) =>
+  state.auth.profileError;

--- a/front/src/types/auth.ts
+++ b/front/src/types/auth.ts
@@ -54,11 +54,11 @@ export interface CognitoUser {
  * 認証状態管理型
  *
  * @description アプリケーション全体の認証状態を管理する Redux state です。
- * ログイン状態、トークン、エラー情報を含みます。
+ * ログイン状態、トークン、エラー情報、プロフィール状態を含みます。
  *
  * @example
  * ```typescript
- * // ログイン済み状態
+ * // ログイン済み・プロフィール作成済み状態
  * const loggedInState: AuthState = {
  *   isAuthenticated: true,
  *   isLoading: false,
@@ -66,7 +66,24 @@ export interface CognitoUser {
  *   accessToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
  *   idToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
  *   refreshToken: "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ...",
- *   error: null
+ *   error: null,
+ *   hasProfile: true,
+ *   isCheckingProfile: false,
+ *   profileError: null
+ * };
+ *
+ * // ログイン済み・プロフィール未作成状態
+ * const noProfileState: AuthState = {
+ *   isAuthenticated: true,
+ *   isLoading: false,
+ *   user: { sub: "...", email: "user@example.com", ... },
+ *   accessToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+ *   idToken: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+ *   refreshToken: "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ...",
+ *   error: null,
+ *   hasProfile: false,
+ *   isCheckingProfile: false,
+ *   profileError: null
  * };
  *
  * // 未ログイン状態
@@ -77,7 +94,10 @@ export interface CognitoUser {
  *   accessToken: null,
  *   idToken: null,
  *   refreshToken: null,
- *   error: null
+ *   error: null,
+ *   hasProfile: null,
+ *   isCheckingProfile: false,
+ *   profileError: null
  * };
  * ```
  */
@@ -96,6 +116,12 @@ export interface AuthState {
   refreshToken: string | null;
   /** 認証エラーメッセージ（エラーなしの場合はnull） */
   error: string | null;
+  /** プロフィール存在フラグ（null: 未チェック, true: 存在, false: 未作成） */
+  hasProfile: boolean | null;
+  /** プロフィールチェック処理中フラグ */
+  isCheckingProfile: boolean;
+  /** プロフィール関連エラーメッセージ（エラーなしの場合はnull） */
+  profileError: string | null;
 }
 
 /**
@@ -268,17 +294,31 @@ export interface UpdateProfileInput {
  * @example
  * ```tsx
  * const MyComponent = () => {
- *   const { authState, login, logout } = useAuthContext();
+ *   const { authState, login, logout, checkProfile } = useAuthContext();
  *
  *   const handleLogin = async () => {
  *     try {
  *       await login({ email: "user@example.com", password: "password" });
+ *       
+ *       // ログイン後にプロフィール有無をチェック
+ *       const hasProfile = await checkProfile();
+ *       if (!hasProfile) {
+ *         // プロフィール作成画面に遷移
+ *         router.push('/profile/create');
+ *       }
  *     } catch (error) {
  *       console.error("ログインに失敗しました:", error);
  *     }
  *   };
  *
- *   if (authState.isLoading) return <div>認証処理中...</div>;
+ *   if (authState.isLoading || authState.isCheckingProfile) {
+ *     return <div>処理中...</div>;
+ *   }
+ *   
+ *   if (authState.isAuthenticated && authState.hasProfile === false) {
+ *     return <div>プロフィール作成が必要です</div>;
+ *   }
+ *   
  *   if (authState.isAuthenticated) return <div>ログイン済み</div>;
  *   return <button onClick={handleLogin}>ログイン</button>;
  * };
@@ -307,6 +347,8 @@ export interface AuthContextType {
   logout: () => Promise<void>;
   /** 認証状態の更新（トークンリフレッシュ） */
   refreshAuth: () => Promise<void>;
+  /** プロフィール有無チェック */
+  checkProfile: () => Promise<boolean>;
   /** エラー状態のクリア */
   clearError: () => void;
 }


### PR DESCRIPTION
## Summary

Issue #56 の実装ステップ4「認証フロー拡張」として、ログイン後のプロフィール自動チェック機能を実装しました。

### 実装内容

#### 1. AuthState プロフィール状態拡張
- `hasProfile`: プロフィール有無の状態（null: 未チェック, true: 存在, false: 未作成）
- `isCheckingProfile`: プロフィールチェック処理中フラグ
- `profileError`: プロフィール関連エラーメッセージ

#### 2. Redux状態管理拡張
- プロフィールチェック用アクション・リデューサー追加
- ログアウト時のプロフィール状態リセット
- 対応するセレクター関数

#### 3. APIレイヤー拡張
- `checkUserProfile()`: プロフィール存在確認関数（boolean返却）
- 404エラーを正常な状態として処理

#### 4. 認証フック拡張
- `checkProfile()`: プロフィール有無チェック関数
- Redux アクション連携とエラーハンドリング

#### 5. 認証プロバイダー拡張
- **認証完了後の自動プロフィールチェック**
- **プロフィール未作成時の `/profile/create` 自動遷移**
- 無限ループ防止とパス条件チェック

### 動作フロー

1. ユーザーログイン成功
2. 認証状態更新
3. **自動プロフィールチェック実行**
4. プロフィール未作成の場合 → `/profile/create` に自動遷移
5. プロフィール作成済みの場合 → 通常フロー継続

### テストプラン

- [ ] ログイン後のプロフィール自動チェック動作確認
- [ ] プロフィール未作成時の自動遷移確認
- [ ] プロフィール作成済み時の正常フロー確認
- [ ] エラー時の適切なハンドリング確認
- [ ] 無限ループ防止の動作確認

## Test plan

- [x] TypeScript型定義の整合性確認
- [x] Redux状態管理の実装確認
- [x] API関数の実装確認
- [x] 認証フローの統合確認
- [ ] ローカル環境での動作確認（品質チェック要実行）
- [ ] プロフィール作成画面への遷移動作確認

## 関連Issue

Closes #56

🤖 Generated with [Claude Code](https://claude.ai/code)